### PR TITLE
Upgrade CAPO version to v0.12.2

### DIFF
--- a/molecule/cluster-api-upgrade/prepare.yml
+++ b/molecule/cluster-api-upgrade/prepare.yml
@@ -24,4 +24,4 @@
         clusterctl_version: 1.6.0
         cluster_api_version: 1.6.0
         cluster_api_infrastructure_provider: openstack
-        cluster_api_infrastructure_version: 0.9.0
+        cluster_api_infrastructure_version: 0.11.2

--- a/molecule/cluster-api/molecule.yml
+++ b/molecule/cluster-api/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
         clusterctl_version: 1.8.4
         cluster_api_version: 1.8.4
         cluster_api_infrastructure_provider: openstack
-        cluster_api_infrastructure_version: 0.11.2
+        cluster_api_infrastructure_version: 0.12.2
         cluster_api_node_selector:
           kubernetes.io/os: linux
         keepalived_interface: "{{ ansible_facts['default_ipv4'].interface }}"

--- a/molecule/cluster-api/molecule.yml
+++ b/molecule/cluster-api/molecule.yml
@@ -33,6 +33,7 @@ provisioner:
         cluster_api_version: 1.9.6
         cluster_api_infrastructure_provider: openstack
         cluster_api_infrastructure_version: 0.12.2
+        cluster_api_openstack_controller_version: 2.0.3
         cluster_api_node_selector:
           kubernetes.io/os: linux
         keepalived_interface: "{{ ansible_facts['default_ipv4'].interface }}"

--- a/molecule/cluster-api/molecule.yml
+++ b/molecule/cluster-api/molecule.yml
@@ -29,8 +29,8 @@ provisioner:
           operator:
             replicas: 1
       controllers:
-        clusterctl_version: 1.8.4
-        cluster_api_version: 1.8.4
+        clusterctl_version: 1.9.6
+        cluster_api_version: 1.9.6
         cluster_api_infrastructure_provider: openstack
         cluster_api_infrastructure_version: 0.12.2
         cluster_api_node_selector:

--- a/roles/cluster_api/defaults/main.yml
+++ b/roles/cluster_api/defaults/main.yml
@@ -20,6 +20,9 @@ cluster_api_control_plane_version: "{{ cluster_api_version }}"
 # cluster_api_infrastructure_provider:
 # cluster_api_infrastructure_version:
 
+cluster_api_openstack_controller_image: quay.io/orc/openstack-resource-controller
+cluster_api_openstack_controller_version: 2.0.3
+
 cluster_api_node_selector: {}
 
 # https://cluster-api-openstack.sigs.k8s.io/clusteropenstack/configuration.html#timeout-settings

--- a/roles/cluster_api/files/providers/bootstrap-kubeadm/v1.9.6/bootstrap-components.yaml
+++ b/roles/cluster_api/files/providers/bootstrap-kubeadm/v1.9.6/bootstrap-components.yaml
@@ -1,0 +1,7961 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    control-plane: controller-manager
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfig
+    listKind: KubeadmConfigList
+    plural: kubeadmconfigs
+    singular: kubeadmconfig
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmConfig is the Schema for the kubeadmconfigs API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KubeadmConfigSpec defines the desired state of KubeadmConfig.
+              Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: clusterConfiguration along with InitConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server
+                      control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names
+                          for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                HostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that
+                          we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  certificatesDir:
+                    description: |-
+                      CertificatesDir specifies where to store or look for all required certificates.
+                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: |-
+                      ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                      the BindPort is used.
+                      Possible usages are:
+                      e.g. In a cluster with more than one control plane instances, this field should be
+                      assigned the address of the external load balancer in front of the
+                      control plane instances.
+                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                      could be used for assigning a stable DNS to the control plane.
+                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the
+                      controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                HostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed
+                      in the cluster.
+                    properties:
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                      type:
+                        description: Type defines the DNS add-on to be used
+                        type: string
+                    type: object
+                  etcd:
+                    description: |-
+                      Etcd holds configuration for etcd.
+                      NB: This value defaults to a Local (stacked) etcd
+                    properties:
+                      external:
+                        description: |-
+                          External describes how to connect to an external etcd cluster
+                          Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: |-
+                              CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: |-
+                              CertFile is an SSL certification file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: |-
+                              KeyFile is an SSL key file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: |-
+                          Local provides configuration knobs for configuring the local etcd instance
+                          Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: |-
+                              DataDir is the directory etcd will place its data.
+                              Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs are extra arguments provided to the etcd binary
+                              when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative
+                              Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative
+                              Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: |-
+                      ImageRepository sets the container registry to pull images from.
+                      If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                      `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                      will be used for all the other images.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  kubernetesVersion:
+                    description: |-
+                      KubernetesVersion is the target version of the control plane.
+                      NB: This value defaults to the Machine object spec.version
+                    type: string
+                  networking:
+                    description: |-
+                      Networking holds configuration for the networking topology of the cluster.
+                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services.
+                          Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: |-
+                          PodSubnet is the subnet used by pods.
+                          If unset, the API server will not allocate CIDR ranges for every node.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: |-
+                          ServiceSubnet is the subnet used by k8s services.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                          to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler
+                      control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                HostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  useHyperKubeImage:
+                    description: UseHyperKubeImage controls if hyperkube should be
+                      used for Kubernetes components instead of their respective separate
+                      images
+                    type: boolean
+                type: object
+              diskSetup:
+                description: diskSetup specifies options for the creation of partition
+                  tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: filesystems specifies the list of file systems to
+                      setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: extraOpts defined extra options to add to the
+                            command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: label specifies the file system label to be
+                            used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: |-
+                            overwrite defines whether or not to overwrite any existing filesystem.
+                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'partition specifies the partition to use.
+                            The valid options are: "auto|any", "auto", "any", "none",
+                            and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: |-
+                            replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: partitions specifies the list of the partitions to
+                      setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: device is the name of the device.
+                          type: string
+                        layout:
+                          description: |-
+                            layout specifies the device layout.
+                            If it is true, a single partition will be created for the entire device.
+                            When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: |-
+                            overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                            Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: |-
+                            tableType specifies the tupe of partition table. The following are supported:
+                            'mbr': default and setups a MS-DOS partition table
+                            'gpt': setups a GPT partition table
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  description: File defines the input for generating write_files in
+                    cloud-init.
+                  properties:
+                    content:
+                      description: content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: contentFrom is a referenced source of content to
+                        populate the file.
+                      properties:
+                        secret:
+                          description: secret represents a secret that should populate
+                            this file.
+                          properties:
+                            key:
+                              description: key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: owner specifies the ownership of the file, e.g.
+                        "root:root".
+                      type: string
+                    path:
+                      description: path specifies the full path on disk where to store
+                        the file.
+                      type: string
+                    permissions:
+                      description: permissions specifies the permissions to assign
+                        to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                type: string
+              initConfiguration:
+                description: initConfiguration along with ClusterConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  bootstrapTokens:
+                    description: |-
+                      BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored
+                        as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: |-
+                            Description sets a human-friendly message why this token exists and what it's used
+                            for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: |-
+                            Expires specifies the timestamp when this token expires. Defaults to being set
+                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: |-
+                            Groups specifies the extra groups that this token will authenticate as when/if
+                            used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: |-
+                            Token is used for establishing bidirectional trust between nodes and control-planes.
+                            Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: |-
+                            TTL defines the time to live for this token. Defaults to 24h.
+                            Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: |-
+                            Usages describes the ways in which this token can be used. Can by default be used
+                            for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  localAPIEndpoint:
+                    description: |-
+                      LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                      fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the
+                          API server to advertise.
+                        type: string
+                      bindPort:
+                        description: |-
+                          BindPort sets the secure port for the API Server to bind to.
+                          Defaults to 6443.
+                        format: int32
+                        type: integer
+                    required:
+                    - advertiseAddress
+                    - bindPort
+                    type: object
+                  nodeRegistration:
+                    description: |-
+                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: |-
+                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              joinConfiguration:
+                description: joinConfiguration is the kubeadm configuration for the
+                  join command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  caCertPath:
+                    description: |-
+                      CACertPath is the path to the SSL certificate authority used to
+                      secure comunications between node and control-plane.
+                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                    type: string
+                  controlPlane:
+                    description: |-
+                      ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                      If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the
+                          API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                    type: object
+                  discovery:
+                    description: Discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
+                    properties:
+                      bootstrapToken:
+                        description: |-
+                          BootstrapToken is used to set the options for bootstrap token based discovery
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name
+                              to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: |-
+                              CACertHashes specifies a set of public key pins to verify
+                              when token-based discovery is used. The root CA found during discovery
+                              must match one of these values. Specifying an empty set disables root CA
+                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                              where the only currently supported type is "sha256". This is a hex-encoded
+                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: |-
+                              Token is a token used to validate cluster information
+                              fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: |-
+                              UnsafeSkipCAVerification allows token-based discovery
+                              without CA verification via CACertHashes. This can weaken
+                              the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        - unsafeSkipCAVerification
+                        type: object
+                      file:
+                        description: |-
+                          File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual
+                              file path or URL to the kubeconfig file from which to
+                              load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: |-
+                          TLSBootstrapToken is a token used for TLS bootstrapping.
+                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  nodeRegistration:
+                    description: |-
+                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: |-
+                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              mounts:
+                description: mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: ntp specifies NTP configuration
+                properties:
+                  enabled:
+                    description: enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: postKubeadmCommands specifies extra commands to run after
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: preKubeadmCommands specifies extra commands to run before
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: |-
+                  useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                  script with retries for joins.
+
+                  This is meant to be an experimental temporary workaround on some environments
+                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                  kubeadm proper and use that functionality.
+
+                  This will add about 40KB to userdata
+
+                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                type: boolean
+              users:
+                description: users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: groups specifies the additional groups for the
+                        user
+                      type: string
+                    homeDir:
+                      description: homeDir specifies the home directory to use for
+                        the user
+                      type: string
+                    inactive:
+                      description: inactive specifies whether to mark the user as
+                        inactive
+                      type: boolean
+                    lockPassword:
+                      description: lockPassword specifies if password login should
+                        be disabled
+                      type: boolean
+                    name:
+                      description: name specifies the user name
+                      type: string
+                    passwd:
+                      description: passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: primaryGroup specifies the primary group for the
+                        user
+                      type: string
+                    shell:
+                      description: shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: sshAuthorizedKeys specifies a list of ssh authorized
+                        keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: |-
+                  verbosity is the number for the kubeadm log level verbosity.
+                  It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              bootstrapData:
+                description: |-
+                  bootstrapData will be a cloud-init script for now.
+
+                  Deprecated: Switch to DataSecretName.
+                format: byte
+                type: string
+              conditions:
+                description: conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: dataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: failureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: failureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmConfig is the Schema for the kubeadmconfigs API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KubeadmConfigSpec defines the desired state of KubeadmConfig.
+              Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: clusterConfiguration along with InitConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: apiServer contains extra settings for the API server
+                      control plane component
+                    properties:
+                      certSANs:
+                        description: certSANs sets extra Subject Alternative Names
+                          for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: timeoutForControlPlane controls the timeout that
+                          we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  certificatesDir:
+                    description: |-
+                      certificatesDir specifies where to store or look for all required certificates.
+                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: |-
+                      controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                      the BindPort is used.
+                      Possible usages are:
+                      e.g. In a cluster with more than one control plane instances, this field should be
+                      assigned the address of the external load balancer in front of the
+                      control plane instances.
+                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                      could be used for assigning a stable DNS to the control plane.
+                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                    type: string
+                  controllerManager:
+                    description: controllerManager contains extra settings for the
+                      controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: dns defines the options for the DNS add-on installed
+                      in the cluster.
+                    properties:
+                      imageRepository:
+                        description: |-
+                          imageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: |-
+                          imageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  etcd:
+                    description: |-
+                      etcd holds configuration for etcd.
+                      NB: This value defaults to a Local (stacked) etcd
+                    properties:
+                      external:
+                        description: |-
+                          external describes how to connect to an external etcd cluster
+                          Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: |-
+                              caFile is an SSL Certificate Authority file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: |-
+                              certFile is an SSL certification file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: |-
+                              keyFile is an SSL key file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: |-
+                          local provides configuration knobs for configuring the local etcd instance
+                          Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: |-
+                              dataDir is the directory etcd will place its data.
+                              Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              extraArgs are extra arguments provided to the etcd binary
+                              when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              imageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: peerCertSANs sets extra Subject Alternative
+                              Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: serverCertSANs sets extra Subject Alternative
+                              Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: featureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: |-
+                      imageRepository sets the container registry to pull images from.
+                      If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                      `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                      will be used for all the other images.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  kubernetesVersion:
+                    description: |-
+                      kubernetesVersion is the target version of the control plane.
+                      NB: This value defaults to the Machine object spec.version
+                    type: string
+                  networking:
+                    description: |-
+                      networking holds configuration for the networking topology of the cluster.
+                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                    properties:
+                      dnsDomain:
+                        description: dnsDomain is the dns domain used by k8s services.
+                          Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: |-
+                          podSubnet is the subnet used by pods.
+                          If unset, the API server will not allocate CIDR ranges for every node.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: |-
+                          serviceSubnet is the subnet used by k8s services.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                          to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: scheduler contains extra settings for the scheduler
+                      control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: diskSetup specifies options for the creation of partition
+                  tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: filesystems specifies the list of file systems to
+                      setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: extraOpts defined extra options to add to the
+                            command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: label specifies the file system label to be
+                            used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: |-
+                            overwrite defines whether or not to overwrite any existing filesystem.
+                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'partition specifies the partition to use.
+                            The valid options are: "auto|any", "auto", "any", "none",
+                            and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: |-
+                            replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: partitions specifies the list of the partitions to
+                      setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: device is the name of the device.
+                          type: string
+                        layout:
+                          description: |-
+                            layout specifies the device layout.
+                            If it is true, a single partition will be created for the entire device.
+                            When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: |-
+                            overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                            Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: |-
+                            tableType specifies the tupe of partition table. The following are supported:
+                            'mbr': default and setups a MS-DOS partition table
+                            'gpt': setups a GPT partition table
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  description: File defines the input for generating write_files in
+                    cloud-init.
+                  properties:
+                    content:
+                      description: content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: contentFrom is a referenced source of content to
+                        populate the file.
+                      properties:
+                        secret:
+                          description: secret represents a secret that should populate
+                            this file.
+                          properties:
+                            key:
+                              description: key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: owner specifies the ownership of the file, e.g.
+                        "root:root".
+                      type: string
+                    path:
+                      description: path specifies the full path on disk where to store
+                        the file.
+                      type: string
+                    permissions:
+                      description: permissions specifies the permissions to assign
+                        to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                type: string
+              initConfiguration:
+                description: initConfiguration along with ClusterConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  bootstrapTokens:
+                    description: |-
+                      bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored
+                        as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: |-
+                            description sets a human-friendly message why this token exists and what it's used
+                            for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: |-
+                            expires specifies the timestamp when this token expires. Defaults to being set
+                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: |-
+                            groups specifies the extra groups that this token will authenticate as when/if
+                            used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: |-
+                            token is used for establishing bidirectional trust between nodes and control-planes.
+                            Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: |-
+                            ttl defines the time to live for this token. Defaults to 24h.
+                            Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: |-
+                            usages describes the ways in which this token can be used. Can by default be used
+                            for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  localAPIEndpoint:
+                    description: |-
+                      localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                      fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: advertiseAddress sets the IP address for the
+                          API server to advertise.
+                        type: string
+                      bindPort:
+                        description: |-
+                          bindPort sets the secure port for the API Server to bind to.
+                          Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: |-
+                      nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: criSocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: ignorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: |-
+                          taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              joinConfiguration:
+                description: joinConfiguration is the kubeadm configuration for the
+                  join command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  caCertPath:
+                    description: |-
+                      caCertPath is the path to the SSL certificate authority used to
+                      secure comunications between node and control-plane.
+                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                    type: string
+                  controlPlane:
+                    description: |-
+                      controlPlane defines the additional control plane instance to be deployed on the joining node.
+                      If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: localAPIEndpoint represents the endpoint of the
+                          API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: advertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              bindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
+                    properties:
+                      bootstrapToken:
+                        description: |-
+                          bootstrapToken is used to set the options for bootstrap token based discovery
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: apiServerEndpoint is an IP or domain name
+                              to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: |-
+                              caCertHashes specifies a set of public key pins to verify
+                              when token-based discovery is used. The root CA found during discovery
+                              must match one of these values. Specifying an empty set disables root CA
+                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                              where the only currently supported type is "sha256". This is a hex-encoded
+                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: |-
+                              token is a token used to validate cluster information
+                              fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: |-
+                              unsafeSkipCAVerification allows token-based discovery
+                              without CA verification via CACertHashes. This can weaken
+                              the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        type: object
+                      file:
+                        description: |-
+                          file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: kubeConfigPath is used to specify the actual
+                              file path or URL to the kubeconfig file from which to
+                              load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: |-
+                          tlsBootstrapToken is a token used for TLS bootstrapping.
+                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  nodeRegistration:
+                    description: |-
+                      nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: criSocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: ignorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: |-
+                          taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              mounts:
+                description: mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: ntp specifies NTP configuration
+                properties:
+                  enabled:
+                    description: enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: postKubeadmCommands specifies extra commands to run after
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: preKubeadmCommands specifies extra commands to run before
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: |-
+                  useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                  script with retries for joins.
+
+                  This is meant to be an experimental temporary workaround on some environments
+                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                  kubeadm proper and use that functionality.
+
+                  This will add about 40KB to userdata
+
+                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                type: boolean
+              users:
+                description: users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: groups specifies the additional groups for the
+                        user
+                      type: string
+                    homeDir:
+                      description: homeDir specifies the home directory to use for
+                        the user
+                      type: string
+                    inactive:
+                      description: inactive specifies whether to mark the user as
+                        inactive
+                      type: boolean
+                    lockPassword:
+                      description: lockPassword specifies if password login should
+                        be disabled
+                      type: boolean
+                    name:
+                      description: name specifies the user name
+                      type: string
+                    passwd:
+                      description: passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: primaryGroup specifies the primary group for the
+                        user
+                      type: string
+                    shell:
+                      description: shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: sshAuthorizedKeys specifies a list of ssh authorized
+                        keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: |-
+                  verbosity is the number for the kubeadm log level verbosity.
+                  It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: dataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: failureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: failureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Time duration since creation of KubeadmConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KubeadmConfigSpec defines the desired state of KubeadmConfig.
+              Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: clusterConfiguration along with InitConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: apiServer contains extra settings for the API server
+                      control plane component
+                    properties:
+                      certSANs:
+                        description: certSANs sets extra Subject Alternative Names
+                          for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraEnvs:
+                        description: |-
+                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: timeoutForControlPlane controls the timeout that
+                          we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  certificatesDir:
+                    description: |-
+                      certificatesDir specifies where to store or look for all required certificates.
+                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: |-
+                      controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                      the BindPort is used.
+                      Possible usages are:
+                      e.g. In a cluster with more than one control plane instances, this field should be
+                      assigned the address of the external load balancer in front of the
+                      control plane instances.
+                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                      could be used for assigning a stable DNS to the control plane.
+                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                    type: string
+                  controllerManager:
+                    description: controllerManager contains extra settings for the
+                      controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraEnvs:
+                        description: |-
+                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: dns defines the options for the DNS add-on installed
+                      in the cluster.
+                    properties:
+                      imageRepository:
+                        description: |-
+                          imageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: |-
+                          imageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  etcd:
+                    description: |-
+                      etcd holds configuration for etcd.
+                      NB: This value defaults to a Local (stacked) etcd
+                    properties:
+                      external:
+                        description: |-
+                          external describes how to connect to an external etcd cluster
+                          Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: |-
+                              caFile is an SSL Certificate Authority file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: |-
+                              certFile is an SSL certification file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: |-
+                              keyFile is an SSL key file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: |-
+                          local provides configuration knobs for configuring the local etcd instance
+                          Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: |-
+                              dataDir is the directory etcd will place its data.
+                              Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              extraArgs are extra arguments provided to the etcd binary
+                              when run inside a static pod.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              imageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: peerCertSANs sets extra Subject Alternative
+                              Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: serverCertSANs sets extra Subject Alternative
+                              Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: featureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: |-
+                      imageRepository sets the container registry to pull images from.
+                      * If not set, the default registry of kubeadm will be used, i.e.
+                        * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                        * k8s.gcr.io (old registry): all older versions
+                        Please note that when imageRepository is not set we don't allow upgrades to
+                        versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                        a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                        >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                      * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                       `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                        and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  kubernetesVersion:
+                    description: |-
+                      kubernetesVersion is the target version of the control plane.
+                      NB: This value defaults to the Machine object spec.version
+                    type: string
+                  networking:
+                    description: |-
+                      networking holds configuration for the networking topology of the cluster.
+                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                    properties:
+                      dnsDomain:
+                        description: dnsDomain is the dns domain used by k8s services.
+                          Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: |-
+                          podSubnet is the subnet used by pods.
+                          If unset, the API server will not allocate CIDR ranges for every node.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: |-
+                          serviceSubnet is the subnet used by k8s services.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                          to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: scheduler contains extra settings for the scheduler
+                      control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraEnvs:
+                        description: |-
+                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: diskSetup specifies options for the creation of partition
+                  tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: filesystems specifies the list of file systems to
+                      setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: extraOpts defined extra options to add to the
+                            command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: label specifies the file system label to be
+                            used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: |-
+                            overwrite defines whether or not to overwrite any existing filesystem.
+                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'partition specifies the partition to use.
+                            The valid options are: "auto|any", "auto", "any", "none",
+                            and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: |-
+                            replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: partitions specifies the list of the partitions to
+                      setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: device is the name of the device.
+                          type: string
+                        layout:
+                          description: |-
+                            layout specifies the device layout.
+                            If it is true, a single partition will be created for the entire device.
+                            When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: |-
+                            overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                            Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: |-
+                            tableType specifies the tupe of partition table. The following are supported:
+                            'mbr': default and setups a MS-DOS partition table
+                            'gpt': setups a GPT partition table
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  description: File defines the input for generating write_files in
+                    cloud-init.
+                  properties:
+                    append:
+                      description: append specifies whether to append Content to existing
+                        file if Path exists.
+                      type: boolean
+                    content:
+                      description: content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: contentFrom is a referenced source of content to
+                        populate the file.
+                      properties:
+                        secret:
+                          description: secret represents a secret that should populate
+                            this file.
+                          properties:
+                            key:
+                              description: key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: owner specifies the ownership of the file, e.g.
+                        "root:root".
+                      type: string
+                    path:
+                      description: path specifies the full path on disk where to store
+                        the file.
+                      type: string
+                    permissions:
+                      description: permissions specifies the permissions to assign
+                        to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                - ignition
+                type: string
+              ignition:
+                description: ignition contains Ignition specific configuration.
+                properties:
+                  containerLinuxConfig:
+                    description: containerLinuxConfig contains CLC specific configuration.
+                    properties:
+                      additionalConfig:
+                        description: |-
+                          additionalConfig contains additional configuration to be merged with the Ignition
+                          configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                          The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                        type: string
+                      strict:
+                        description: strict controls if AdditionalConfig should be
+                          strictly parsed. If so, warnings are treated as errors.
+                        type: boolean
+                    type: object
+                type: object
+              initConfiguration:
+                description: initConfiguration along with ClusterConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  bootstrapTokens:
+                    description: |-
+                      bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored
+                        as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: |-
+                            description sets a human-friendly message why this token exists and what it's used
+                            for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: |-
+                            expires specifies the timestamp when this token expires. Defaults to being set
+                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: |-
+                            groups specifies the extra groups that this token will authenticate as when/if
+                            used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: |-
+                            token is used for establishing bidirectional trust between nodes and control-planes.
+                            Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: |-
+                            ttl defines the time to live for this token. Defaults to 24h.
+                            Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: |-
+                            usages describes the ways in which this token can be used. Can by default be used
+                            for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  localAPIEndpoint:
+                    description: |-
+                      localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                      fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: advertiseAddress sets the IP address for the
+                          API server to advertise.
+                        type: string
+                      bindPort:
+                        description: |-
+                          bindPort sets the secure port for the API Server to bind to.
+                          Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: |-
+                      nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: criSocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: ignorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      imagePullPolicy:
+                        description: |-
+                          imagePullPolicy specifies the policy for image pulling
+                          during kubeadm "init" and "join" operations. The value of
+                          this field must be one of "Always", "IfNotPresent" or
+                          "Never". Defaults to "IfNotPresent". This can be used only
+                          with Kubernetes version equal to 1.22 and later.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSerial:
+                        description: |-
+                          imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                          Default: true (defaulted in kubeadm)
+                        type: boolean
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: |-
+                          taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                  patches:
+                    description: |-
+                      patches contains options related to applying patches to components deployed by kubeadm during
+                      "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: |-
+                          directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                          "suffix" is an optional string that can be used to determine which patches are applied
+                          first alpha-numerically.
+                          These files can be written into the target directory via KubeadmConfig.Files which
+                          specifies additional files to be created on the machine, either with content inline or
+                          by referencing a secret.
+                        type: string
+                    type: object
+                  skipPhases:
+                    description: |-
+                      skipPhases is a list of phases to skip during command execution.
+                      The list of phases can be obtained with the "kubeadm init --help" command.
+                      This option takes effect only on Kubernetes >=1.22.0.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              joinConfiguration:
+                description: joinConfiguration is the kubeadm configuration for the
+                  join command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  caCertPath:
+                    description: |-
+                      caCertPath is the path to the SSL certificate authority used to
+                      secure comunications between node and control-plane.
+                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                    type: string
+                  controlPlane:
+                    description: |-
+                      controlPlane defines the additional control plane instance to be deployed on the joining node.
+                      If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: localAPIEndpoint represents the endpoint of the
+                          API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: advertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              bindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
+                    properties:
+                      bootstrapToken:
+                        description: |-
+                          bootstrapToken is used to set the options for bootstrap token based discovery
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: apiServerEndpoint is an IP or domain name
+                              to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: |-
+                              caCertHashes specifies a set of public key pins to verify
+                              when token-based discovery is used. The root CA found during discovery
+                              must match one of these values. Specifying an empty set disables root CA
+                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                              where the only currently supported type is "sha256". This is a hex-encoded
+                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: |-
+                              token is a token used to validate cluster information
+                              fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: |-
+                              unsafeSkipCAVerification allows token-based discovery
+                              without CA verification via CACertHashes. This can weaken
+                              the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        type: object
+                      file:
+                        description: |-
+                          file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfig:
+                            description: |-
+                              kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                              The file is generated at the path specified in KubeConfigPath.
+
+                              Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                              Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                            properties:
+                              cluster:
+                                description: |-
+                                  cluster contains information about how to communicate with the kubernetes cluster.
+
+                                  By default the following fields are automatically populated:
+                                  - Server with the Cluster's ControlPlaneEndpoint.
+                                  - CertificateAuthorityData with the Cluster's CA certificate.
+                                properties:
+                                  certificateAuthorityData:
+                                    description: |-
+                                      certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                      Defaults to the Cluster's CA certificate if empty.
+                                    format: byte
+                                    type: string
+                                  insecureSkipTLSVerify:
+                                    description: insecureSkipTLSVerify skips the validity
+                                      check for the server's certificate. This will
+                                      make your HTTPS connections insecure.
+                                    type: boolean
+                                  proxyURL:
+                                    description: |-
+                                      proxyURL is the URL to the proxy to be used for all requests made by this
+                                      client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                      this configuration is not provided or the empty string, the client
+                                      attempts to construct a proxy configuration from http_proxy and
+                                      https_proxy environment variables. If these environment variables are not
+                                      set, the client does not attempt to proxy requests.
+
+                                      socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                      attach, port forward).
+                                    type: string
+                                  server:
+                                    description: |-
+                                      server is the address of the kubernetes cluster (https://hostname:port).
+
+                                      Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                    type: string
+                                  tlsServerName:
+                                    description: tlsServerName is used to check server
+                                      certificate. If TLSServerName is empty, the
+                                      hostname used to contact the server is used.
+                                    type: string
+                                type: object
+                              user:
+                                description: |-
+                                  user contains information that describes identity information.
+                                  This is used to tell the kubernetes cluster who you are.
+                                properties:
+                                  authProvider:
+                                    description: authProvider specifies a custom authentication
+                                      plugin for the kubernetes cluster.
+                                    properties:
+                                      config:
+                                        additionalProperties:
+                                          type: string
+                                        description: config holds the parameters for
+                                          the authentication plugin.
+                                        type: object
+                                      name:
+                                        description: name is the name of the authentication
+                                          plugin.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  exec:
+                                    description: exec specifies a custom exec-based
+                                      authentication plugin for the kubernetes cluster.
+                                    properties:
+                                      apiVersion:
+                                        description: |-
+                                          Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                          the same encoding version as the input.
+                                          Defaults to client.authentication.k8s.io/v1 if not set.
+                                        type: string
+                                      args:
+                                        description: Arguments to pass to the command
+                                          when executing it.
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        description: command to execute.
+                                        type: string
+                                      env:
+                                        description: |-
+                                          env defines additional environment variables to expose to the process. These
+                                          are unioned with the host's environment, as well as variables client-go uses
+                                          to pass argument to the plugin.
+                                        items:
+                                          description: |-
+                                            KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                            credential plugin.
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      provideClusterInfo:
+                                        description: |-
+                                          provideClusterInfo determines whether or not to provide cluster information,
+                                          which could potentially contain very large CA data, to this exec plugin as a
+                                          part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                          to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                          reading this environment variable.
+                                        type: boolean
+                                    required:
+                                    - command
+                                    type: object
+                                type: object
+                            required:
+                            - user
+                            type: object
+                          kubeConfigPath:
+                            description: kubeConfigPath is used to specify the actual
+                              file path or URL to the kubeconfig file from which to
+                              load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: |-
+                          tlsBootstrapToken is a token used for TLS bootstrapping.
+                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  nodeRegistration:
+                    description: |-
+                      nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: criSocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: ignorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      imagePullPolicy:
+                        description: |-
+                          imagePullPolicy specifies the policy for image pulling
+                          during kubeadm "init" and "join" operations. The value of
+                          this field must be one of "Always", "IfNotPresent" or
+                          "Never". Defaults to "IfNotPresent". This can be used only
+                          with Kubernetes version equal to 1.22 and later.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSerial:
+                        description: |-
+                          imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                          Default: true (defaulted in kubeadm)
+                        type: boolean
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: |-
+                          taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                  patches:
+                    description: |-
+                      patches contains options related to applying patches to components deployed by kubeadm during
+                      "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: |-
+                          directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                          "suffix" is an optional string that can be used to determine which patches are applied
+                          first alpha-numerically.
+                          These files can be written into the target directory via KubeadmConfig.Files which
+                          specifies additional files to be created on the machine, either with content inline or
+                          by referencing a secret.
+                        type: string
+                    type: object
+                  skipPhases:
+                    description: |-
+                      skipPhases is a list of phases to skip during command execution.
+                      The list of phases can be obtained with the "kubeadm init --help" command.
+                      This option takes effect only on Kubernetes >=1.22.0.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              mounts:
+                description: mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: ntp specifies NTP configuration
+                properties:
+                  enabled:
+                    description: enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: postKubeadmCommands specifies extra commands to run after
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: preKubeadmCommands specifies extra commands to run before
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: |-
+                  useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                  script with retries for joins.
+
+                  This is meant to be an experimental temporary workaround on some environments
+                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                  kubeadm proper and use that functionality.
+
+                  This will add about 40KB to userdata
+
+                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                  Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                  When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                type: boolean
+              users:
+                description: users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: groups specifies the additional groups for the
+                        user
+                      type: string
+                    homeDir:
+                      description: homeDir specifies the home directory to use for
+                        the user
+                      type: string
+                    inactive:
+                      description: inactive specifies whether to mark the user as
+                        inactive
+                      type: boolean
+                    lockPassword:
+                      description: lockPassword specifies if password login should
+                        be disabled
+                      type: boolean
+                    name:
+                      description: name specifies the user name
+                      type: string
+                    passwd:
+                      description: passwd specifies a hashed password for the user
+                      type: string
+                    passwdFrom:
+                      description: passwdFrom is a referenced source of passwd to
+                        populate the passwd.
+                      properties:
+                        secret:
+                          description: secret represents a secret that should populate
+                            this password.
+                          properties:
+                            key:
+                              description: key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    primaryGroup:
+                      description: primaryGroup specifies the primary group for the
+                        user
+                      type: string
+                    shell:
+                      description: shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: sshAuthorizedKeys specifies a list of ssh authorized
+                        keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: |-
+                  verbosity is the number for the kubeadm log level verbosity.
+                  It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: dataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: |-
+                  failureMessage will be set on non-retryable errors
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set on non-retryable errors
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in KubeadmConfig's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a KubeadmConfig's current state.
+                      Known condition types are Ready, DataSecretAvailable, CertificatesAvailable.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfigTemplate
+    listKind: KubeadmConfigTemplateList
+    plural: kubeadmconfigtemplates
+    singular: kubeadmconfigtemplate
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: |-
+                      KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                      Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: clusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the
+                              API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative
+                                  Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings
+                              for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on
+                              installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              type:
+                                description: Type defines the DNS add-on to be used
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required
+                                      for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject
+                                      Alternative Names for the etcd server signing
+                                      cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                              `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                              will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s
+                                  services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the
+                              scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          useHyperKubeImage:
+                            description: UseHyperKubeImage controls if hyperkube should
+                              be used for Kubernetes components instead of their respective
+                              separate images
+                            type: boolean
+                        type: object
+                      diskSetup:
+                        description: diskSetup specifies options for the creation
+                          of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to
+                                be created.
+                              properties:
+                                device:
+                                  description: device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: extraOpts defined extra options to
+                                    add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: filesystem specifies the file system
+                                    type.
+                                  type: string
+                                label:
+                                  description: label specifies the file system label
+                                    to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'partition specifies the partition
+                                    to use. The valid options are: "auto|any", "auto",
+                                    "any", "none", and <NUM>, where NUM is the actual
+                                    partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    tableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            content:
+                              description: content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: contentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: encoding specifies the encoding of the
+                                file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: permissions specifies the permissions to
+                                assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: initConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap
+                                token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: joinConfiguration is the kubeadm configuration
+                          for the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this
+                                  node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                            type: object
+                          discovery:
+                            description: Discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will
+                                      be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                - unsafeSkipCAVerification
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify
+                                      the actual file path or URL to the kubeconfig
+                                      file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: mounts specifies a list of mount points to be
+                          setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: ntp specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: postKubeadmCommands specifies extra commands
+                          to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: preKubeadmCommands specifies extra commands to
+                          run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+                          This will add about 40KB to userdata
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                        type: boolean
+                      users:
+                        description: users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user
+                            in cloud-init.
+                          properties:
+                            gecos:
+                              description: gecos specifies the gecos to use for the
+                                user
+                              type: string
+                            groups:
+                              description: groups specifies the additional groups
+                                for the user
+                              type: string
+                            homeDir:
+                              description: homeDir specifies the home directory to
+                                use for the user
+                              type: string
+                            inactive:
+                              description: inactive specifies whether to mark the
+                                user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: lockPassword specifies if password login
+                                should be disabled
+                              type: boolean
+                            name:
+                              description: name specifies the user name
+                              type: string
+                            passwd:
+                              description: passwd specifies a hashed password for
+                                the user
+                              type: string
+                            primaryGroup:
+                              description: primaryGroup specifies the primary group
+                                for the user
+                              type: string
+                            shell:
+                              description: shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: sshAuthorizedKeys specifies a list of ssh
+                                authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: |-
+                      KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                      Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: clusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: apiServer contains extra settings for the
+                              API server control plane component
+                            properties:
+                              certSANs:
+                                description: certSANs sets extra Subject Alternative
+                                  Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: timeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              certificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: controllerManager contains extra settings
+                              for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: dns defines the options for the DNS add-on
+                              installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  imageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  external describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      certFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: endpoints of etcd members. Required
+                                      for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      keyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      dataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      extraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      imageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      imageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: peerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: serverCertSANs sets extra Subject
+                                      Alternative Names for the etcd server signing
+                                      cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: featureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                              `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                              will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              kubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: dnsDomain is the dns domain used by k8s
+                                  services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  podSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  serviceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: scheduler contains extra settings for the
+                              scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: diskSetup specifies options for the creation
+                          of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to
+                                be created.
+                              properties:
+                                device:
+                                  description: device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: extraOpts defined extra options to
+                                    add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: filesystem specifies the file system
+                                    type.
+                                  type: string
+                                label:
+                                  description: label specifies the file system label
+                                    to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'partition specifies the partition
+                                    to use. The valid options are: "auto|any", "auto",
+                                    "any", "none", and <NUM>, where NUM is the actual
+                                    partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    tableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            content:
+                              description: content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: contentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: encoding specifies the encoding of the
+                                file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: permissions specifies the permissions to
+                                assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: initConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap
+                                token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    ttl defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: advertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  bindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: criSocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: ignorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: joinConfiguration is the kubeadm configuration
+                          for the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              caCertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                            type: string
+                          controlPlane:
+                            description: |-
+                              controlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: localAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this
+                                  node.
+                                properties:
+                                  advertiseAddress:
+                                    description: advertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      bindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  bootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: apiServerEndpoint is an IP or domain
+                                      name to the API server from which info will
+                                      be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      caCertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      unsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: |-
+                                  file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: kubeConfigPath is used to specify
+                                      the actual file path or URL to the kubeconfig
+                                      file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  tlsBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: criSocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: ignorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: mounts specifies a list of mount points to be
+                          setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: ntp specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: postKubeadmCommands specifies extra commands
+                          to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: preKubeadmCommands specifies extra commands to
+                          run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+                          This will add about 40KB to userdata
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                        type: boolean
+                      users:
+                        description: users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user
+                            in cloud-init.
+                          properties:
+                            gecos:
+                              description: gecos specifies the gecos to use for the
+                                user
+                              type: string
+                            groups:
+                              description: groups specifies the additional groups
+                                for the user
+                              type: string
+                            homeDir:
+                              description: homeDir specifies the home directory to
+                                use for the user
+                              type: string
+                            inactive:
+                              description: inactive specifies whether to mark the
+                                user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: lockPassword specifies if password login
+                                should be disabled
+                              type: boolean
+                            name:
+                              description: name specifies the user name
+                              type: string
+                            passwd:
+                              description: passwd specifies a hashed password for
+                                the user
+                              type: string
+                            primaryGroup:
+                              description: primaryGroup specifies the primary group
+                                for the user
+                              type: string
+                            shell:
+                              description: shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: sshAuthorizedKeys specifies a list of ssh
+                                authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                      Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: clusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: apiServer contains extra settings for the
+                              API server control plane component
+                            properties:
+                              certSANs:
+                                description: certSANs sets extra Subject Alternative
+                                  Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: timeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              certificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: controllerManager contains extra settings
+                              for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: dns defines the options for the DNS add-on
+                              installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  imageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  external describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      certFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: endpoints of etcd members. Required
+                                      for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      keyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      dataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      extraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  imageRepository:
+                                    description: |-
+                                      imageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      imageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: peerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: serverCertSANs sets extra Subject
+                                      Alternative Names for the etcd server signing
+                                      cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: featureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              * If not set, the default registry of kubeadm will be used, i.e.
+                                * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                * k8s.gcr.io (old registry): all older versions
+                                Please note that when imageRepository is not set we don't allow upgrades to
+                                versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                              * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                               `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              kubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: dnsDomain is the dns domain used by k8s
+                                  services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  podSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  serviceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: scheduler contains extra settings for the
+                              scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: diskSetup specifies options for the creation
+                          of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to
+                                be created.
+                              properties:
+                                device:
+                                  description: device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: extraOpts defined extra options to
+                                    add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: filesystem specifies the file system
+                                    type.
+                                  type: string
+                                label:
+                                  description: label specifies the file system label
+                                    to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'partition specifies the partition
+                                    to use. The valid options are: "auto|any", "auto",
+                                    "any", "none", and <NUM>, where NUM is the actual
+                                    partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    tableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            append:
+                              description: append specifies whether to append Content
+                                to existing file if Path exists.
+                              type: boolean
+                            content:
+                              description: content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: contentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: encoding specifies the encoding of the
+                                file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: permissions specifies the permissions to
+                                assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        - ignition
+                        type: string
+                      ignition:
+                        description: ignition contains Ignition specific configuration.
+                        properties:
+                          containerLinuxConfig:
+                            description: containerLinuxConfig contains CLC specific
+                              configuration.
+                            properties:
+                              additionalConfig:
+                                description: |-
+                                  additionalConfig contains additional configuration to be merged with the Ignition
+                                  configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                                  The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                type: string
+                              strict:
+                                description: strict controls if AdditionalConfig should
+                                  be strictly parsed. If so, warnings are treated
+                                  as errors.
+                                type: boolean
+                            type: object
+                        type: object
+                      initConfiguration:
+                        description: initConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap
+                                token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    ttl defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: advertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  bindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: criSocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: ignorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  imagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              imagePullSerial:
+                                description: |-
+                                  imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                  Default: true (defaulted in kubeadm)
+                                type: boolean
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              skipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      joinConfiguration:
+                        description: joinConfiguration is the kubeadm configuration
+                          for the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              caCertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                            type: string
+                          controlPlane:
+                            description: |-
+                              controlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: localAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this
+                                  node.
+                                properties:
+                                  advertiseAddress:
+                                    description: advertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      bindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  bootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: apiServerEndpoint is an IP or domain
+                                      name to the API server from which info will
+                                      be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      caCertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      unsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: |-
+                                  file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfig:
+                                    description: |-
+                                      kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                      The file is generated at the path specified in KubeConfigPath.
+
+                                      Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                      Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                    properties:
+                                      cluster:
+                                        description: |-
+                                          cluster contains information about how to communicate with the kubernetes cluster.
+
+                                          By default the following fields are automatically populated:
+                                          - Server with the Cluster's ControlPlaneEndpoint.
+                                          - CertificateAuthorityData with the Cluster's CA certificate.
+                                        properties:
+                                          certificateAuthorityData:
+                                            description: |-
+                                              certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                              Defaults to the Cluster's CA certificate if empty.
+                                            format: byte
+                                            type: string
+                                          insecureSkipTLSVerify:
+                                            description: insecureSkipTLSVerify skips
+                                              the validity check for the server's
+                                              certificate. This will make your HTTPS
+                                              connections insecure.
+                                            type: boolean
+                                          proxyURL:
+                                            description: |-
+                                              proxyURL is the URL to the proxy to be used for all requests made by this
+                                              client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                              this configuration is not provided or the empty string, the client
+                                              attempts to construct a proxy configuration from http_proxy and
+                                              https_proxy environment variables. If these environment variables are not
+                                              set, the client does not attempt to proxy requests.
+
+                                              socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                              attach, port forward).
+                                            type: string
+                                          server:
+                                            description: |-
+                                              server is the address of the kubernetes cluster (https://hostname:port).
+
+                                              Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                            type: string
+                                          tlsServerName:
+                                            description: tlsServerName is used to
+                                              check server certificate. If TLSServerName
+                                              is empty, the hostname used to contact
+                                              the server is used.
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: |-
+                                          user contains information that describes identity information.
+                                          This is used to tell the kubernetes cluster who you are.
+                                        properties:
+                                          authProvider:
+                                            description: authProvider specifies a
+                                              custom authentication plugin for the
+                                              kubernetes cluster.
+                                            properties:
+                                              config:
+                                                additionalProperties:
+                                                  type: string
+                                                description: config holds the parameters
+                                                  for the authentication plugin.
+                                                type: object
+                                              name:
+                                                description: name is the name of the
+                                                  authentication plugin.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          exec:
+                                            description: exec specifies a custom exec-based
+                                              authentication plugin for the kubernetes
+                                              cluster.
+                                            properties:
+                                              apiVersion:
+                                                description: |-
+                                                  Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                  the same encoding version as the input.
+                                                  Defaults to client.authentication.k8s.io/v1 if not set.
+                                                type: string
+                                              args:
+                                                description: Arguments to pass to
+                                                  the command when executing it.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                description: command to execute.
+                                                type: string
+                                              env:
+                                                description: |-
+                                                  env defines additional environment variables to expose to the process. These
+                                                  are unioned with the host's environment, as well as variables client-go uses
+                                                  to pass argument to the plugin.
+                                                items:
+                                                  description: |-
+                                                    KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                    credential plugin.
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              provideClusterInfo:
+                                                description: |-
+                                                  provideClusterInfo determines whether or not to provide cluster information,
+                                                  which could potentially contain very large CA data, to this exec plugin as a
+                                                  part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                  to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                  reading this environment variable.
+                                                type: boolean
+                                            required:
+                                            - command
+                                            type: object
+                                        type: object
+                                    required:
+                                    - user
+                                    type: object
+                                  kubeConfigPath:
+                                    description: kubeConfigPath is used to specify
+                                      the actual file path or URL to the kubeconfig
+                                      file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  tlsBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: criSocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: ignorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  imagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              imagePullSerial:
+                                description: |-
+                                  imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                  Default: true (defaulted in kubeadm)
+                                type: boolean
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              skipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      mounts:
+                        description: mounts specifies a list of mount points to be
+                          setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: ntp specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: postKubeadmCommands specifies extra commands
+                          to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: preKubeadmCommands specifies extra commands to
+                          run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+                          This will add about 40KB to userdata
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                          Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                          When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                        type: boolean
+                      users:
+                        description: users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user
+                            in cloud-init.
+                          properties:
+                            gecos:
+                              description: gecos specifies the gecos to use for the
+                                user
+                              type: string
+                            groups:
+                              description: groups specifies the additional groups
+                                for the user
+                              type: string
+                            homeDir:
+                              description: homeDir specifies the home directory to
+                                use for the user
+                              type: string
+                            inactive:
+                              description: inactive specifies whether to mark the
+                                user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: lockPassword specifies if password login
+                                should be disabled
+                              type: boolean
+                            name:
+                              description: name specifies the user name
+                              type: string
+                            passwd:
+                              description: passwd specifies a hashed password for
+                                the user
+                              type: string
+                            passwdFrom:
+                              description: passwdFrom is a referenced source of passwd
+                                to populate the passwd.
+                              properties:
+                                secret:
+                                  description: secret represents a secret that should
+                                    populate this password.
+                                  properties:
+                                    key:
+                                      description: key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            primaryGroup:
+                              description: primaryGroup specifies the primary group
+                                for the user
+                              type: string
+                            shell:
+                              description: shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: sshAuthorizedKeys specifies a list of ssh
+                                authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-leader-election-role
+  namespace: capi-kubeadm-bootstrap-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - kubeadmconfigs
+  - kubeadmconfigs/finalizers
+  - kubeadmconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machinepools
+  - machinepools/status
+  - machines
+  - machines/status
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-leader-election-rolebinding
+  namespace: capi-kubeadm-bootstrap-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-kubeadm-bootstrap-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kubeadm-bootstrap-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-webhook-service
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    control-plane: controller-manager
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: bootstrap-kubeadm
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+        - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+        - --bootstrap-token-ttl=${KUBEADM_BOOTSTRAP_TOKEN_TTL:=15m}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.6
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: capi-kubeadm-bootstrap-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-kubeadm-bootstrap-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-serving-cert
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  dnsNames:
+  - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc
+  - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-kubeadm-bootstrap-selfsigned-issuer
+  secretName: capi-kubeadm-bootstrap-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-selfsigned-issuer
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+  failurePolicy: Fail
+  name: default.kubeadmconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+  failurePolicy: Fail
+  name: default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigtemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigtemplates
+  sideEffects: None

--- a/roles/cluster_api/files/providers/bootstrap-kubeadm/v1.9.6/metadata.yaml
+++ b/roles/cluster_api/files/providers/bootstrap-kubeadm/v1.9.6/metadata.yaml
@@ -1,0 +1,38 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 9
+    contract: v1beta1
+  - major: 1
+    minor: 8
+    contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1
+  - major: 1
+    minor: 6
+    contract: v1beta1
+  - major: 1
+    minor: 5
+    contract: v1beta1
+  - major: 1
+    minor: 4
+    contract: v1beta1
+  - major: 1
+    minor: 3
+    contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
+    minor: 0
+    contract: v1beta1

--- a/roles/cluster_api/files/providers/cluster-api/v1.9.6/core-components.yaml
+++ b/roles/cluster_api/files/providers/cluster-api/v1.9.6/core-components.yaml
@@ -1,0 +1,14724 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    control-plane: controller-manager
+  name: capi-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterclasses.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterClass
+    listKind: ClusterClassList
+    plural: clusterclasses
+    shortNames:
+    - cc
+    singular: clusterclass
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterClass is a template which can be used to create managed topologies.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: |-
+                  controlPlane is a reference to a local struct that holds the details
+                  for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineInfrastructure:
+                    description: |-
+                      MachineTemplate defines the metadata and infrastructure information
+                      for control plane machines.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      ref:
+                        description: |-
+                          ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: |-
+                      metadata is the metadata applied to the machines of the ControlPlane.
+                      At runtime this metadata is merged with the corresponding metadata from the topology.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced is Machine based.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: |-
+                  infrastructure is a reference to a provider-specific template that holds
+                  the details for provisioning infrastructure specific cluster
+                  for the underlying provider.
+                  The underlying provider is responsible for the implementation
+                  of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              workers:
+                description: |-
+                  workers describes the worker nodes for the cluster.
+                  It is a collection of node types which can be used to create
+                  the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: |-
+                      machineDeployments is a list of machine deployment classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster
+                        provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of worker node present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachineDeployment.
+                          type: string
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed
+          topologies.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: |-
+                  controlPlane is a reference to a local struct that holds the details
+                  for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineHealthCheck:
+                    description: |-
+                      machineHealthCheck defines a MachineHealthCheck for this ControlPlaneClass.
+                      This field is supported if and only if the ControlPlane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      maxUnhealthy:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                          "selector" are not healthy.
+                        x-kubernetes-int-or-string: true
+                      nodeStartupTimeout:
+                        description: |-
+                          nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                          to consider a Machine unhealthy if a corresponding Node isn't associated
+                          through a `Spec.ProviderID` field.
+
+                          The duration set in this field is compared to the greatest of:
+                          - Cluster's infrastructure ready condition timestamp (if and when available)
+                          - Control Plane's initialized condition timestamp (if and when available)
+                          - Machine's infrastructure ready condition timestamp (if and when available)
+                          - Machine's metadata creation timestamp
+
+                          Defaults to 10 minutes.
+                          If you wish to disable this feature, set the value explicitly to 0.
+                        type: string
+                      remediationTemplate:
+                        description: |-
+                          remediationTemplate is a reference to a remediation template
+                          provided by an infrastructure provider.
+
+                          This field is completely optional, when filled, the MachineHealthCheck controller
+                          creates a new object from the template referenced and hands off remediation of the machine to
+                          a controller that lives outside of Cluster API.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      unhealthyConditions:
+                        description: |-
+                          unhealthyConditions contains a list of the conditions that determine
+                          whether a node is considered unhealthy. The conditions are combined in a
+                          logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                        items:
+                          description: |-
+                            UnhealthyCondition represents a Node condition type and value with a timeout
+                            specified as a duration.  When the named condition has been in the given
+                            status for at least the timeout value, a node is considered unhealthy.
+                          properties:
+                            status:
+                              minLength: 1
+                              type: string
+                            timeout:
+                              type: string
+                            type:
+                              minLength: 1
+                              type: string
+                          required:
+                          - status
+                          - timeout
+                          - type
+                          type: object
+                        type: array
+                      unhealthyRange:
+                        description: |-
+                          Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                          is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                          Eg. "[3-5]" - This means that remediation will be allowed only when:
+                          (a) there are at least 3 unhealthy machines (and)
+                          (b) there are at most 5 unhealthy machines
+                        pattern: ^\[[0-9]+-[0-9]+\]$
+                        type: string
+                    type: object
+                  machineInfrastructure:
+                    description: |-
+                      machineInfrastructure defines the metadata and infrastructure information
+                      for control plane machines.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      ref:
+                        description: |-
+                          ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: |-
+                      metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                      if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the
+                      ControlPlane.
+                      At runtime this metadata is merged with the corresponding metadata from the topology.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced is Machine based.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  namingStrategy:
+                    description: namingStrategy allows changing the naming pattern
+                      used when creating the control plane provider object.
+                    properties:
+                      template:
+                        description: |-
+                          template defines the template to use for generating the name of the ControlPlane object.
+                          If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`.
+                          If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                          get concatenated with a random suffix of length 5.
+                          The templating mechanism provides the following arguments:
+                          * `.cluster.name`: The name of the cluster object.
+                          * `.random`: A random alphanumeric string, without vowels, of length 5.
+                        type: string
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      Defaults to 10 seconds.
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: |-
+                  infrastructure is a reference to a provider-specific template that holds
+                  the details for provisioning infrastructure specific cluster
+                  for the underlying provider.
+                  The underlying provider is responsible for the implementation
+                  of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              patches:
+                description: |-
+                  patches defines the patches which are applied to customize
+                  referenced templates of a ClusterClass.
+                  Note: Patches will be applied in the order of the array.
+                items:
+                  description: ClusterClassPatch defines a patch which is applied
+                    to customize the referenced templates.
+                  properties:
+                    definitions:
+                      description: |-
+                        definitions define inline patches.
+                        Note: Patches will be applied in the order of the array.
+                        Note: Exactly one of Definitions or External must be set.
+                      items:
+                        description: PatchDefinition defines a patch which is applied
+                          to customize the referenced templates.
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              jsonPatches defines the patches which should be applied on the templates
+                              matching the selector.
+                              Note: Patches will be applied in the order of the array.
+                            items:
+                              description: JSONPatch defines a JSON patch.
+                              properties:
+                                op:
+                                  description: |-
+                                    op defines the operation of the patch.
+                                    Note: Only `add`, `replace` and `remove` are supported.
+                                  type: string
+                                path:
+                                  description: |-
+                                    path defines the path of the patch.
+                                    Note: Only the spec of a template can be patched, thus the path has to start with /spec/.
+                                    Note: For now the only allowed array modifications are `append` and `prepend`, i.e.:
+                                    * for op: `add`: only index 0 (prepend) and - (append) are allowed
+                                    * for op: `replace` or `remove`: no indexes are allowed
+                                  type: string
+                                value:
+                                  description: |-
+                                    value defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for add and replace
+                                    operations. Only one of them is allowed to be set at the same time.
+                                    Note: We have to use apiextensionsv1.JSON instead of our JSON type,
+                                    because controller-tools has a hard-coded schema for apiextensionsv1.JSON
+                                    which cannot be produced by another type (unset type field).
+                                    Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                  x-kubernetes-preserve-unknown-fields: true
+                                valueFrom:
+                                  description: |-
+                                    valueFrom defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for add and replace
+                                    operations. Only one of them is allowed to be set at the same time.
+                                  properties:
+                                    template:
+                                      description: |-
+                                        template is the Go template to be used to calculate the value.
+                                        A template can reference variables defined in .spec.variables and builtin variables.
+                                        Note: The template must evaluate to a valid YAML or JSON value.
+                                      type: string
+                                    variable:
+                                      description: |-
+                                        variable is the variable to be used as value.
+                                        Variable can be one of the variables defined in .spec.variables or a builtin variable.
+                                      type: string
+                                  type: object
+                              required:
+                              - op
+                              - path
+                              type: object
+                            type: array
+                          selector:
+                            description: selector defines on which templates the patch
+                              should be applied.
+                            properties:
+                              apiVersion:
+                                description: apiVersion filters templates by apiVersion.
+                                type: string
+                              kind:
+                                description: kind filters templates by kind.
+                                type: string
+                              matchResources:
+                                description: matchResources selects templates based
+                                  on where they are referenced.
+                                properties:
+                                  controlPlane:
+                                    description: |-
+                                      controlPlane selects templates referenced in .spec.ControlPlane.
+                                      Note: this will match the controlPlane and also the controlPlane
+                                      machineInfrastructure (depending on the kind and apiVersion).
+                                    type: boolean
+                                  infrastructureCluster:
+                                    description: infrastructureCluster selects templates
+                                      referenced in .spec.infrastructure.
+                                    type: boolean
+                                  machineDeploymentClass:
+                                    description: |-
+                                      machineDeploymentClass selects templates referenced in specific MachineDeploymentClasses in
+                                      .spec.workers.machineDeployments.
+                                    properties:
+                                      names:
+                                        description: names selects templates by class
+                                          names.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  machinePoolClass:
+                                    description: |-
+                                      machinePoolClass selects templates referenced in specific MachinePoolClasses in
+                                      .spec.workers.machinePools.
+                                    properties:
+                                      names:
+                                        description: names selects templates by class
+                                          names.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                            required:
+                            - apiVersion
+                            - kind
+                            - matchResources
+                            type: object
+                        required:
+                        - jsonPatches
+                        - selector
+                        type: object
+                      type: array
+                    description:
+                      description: description is a human-readable description of
+                        this patch.
+                      type: string
+                    enabledIf:
+                      description: |-
+                        enabledIf is a Go template to be used to calculate if a patch should be enabled.
+                        It can reference variables defined in .spec.variables and builtin variables.
+                        The patch will be enabled if the template evaluates to `true`, otherwise it will
+                        be disabled.
+                        If EnabledIf is not set, the patch will be enabled per default.
+                      type: string
+                    external:
+                      description: |-
+                        external defines an external patch.
+                        Note: Exactly one of Definitions or External must be set.
+                      properties:
+                        discoverVariablesExtension:
+                          description: discoverVariablesExtension references an extension
+                            which is called to discover variables.
+                          type: string
+                        generateExtension:
+                          description: generateExtension references an extension which
+                            is called to generate patches.
+                          type: string
+                        settings:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            settings defines key value pairs to be passed to the extensions.
+                            Values defined here take precedence over the values defined in the
+                            corresponding ExtensionConfig.
+                          type: object
+                        validateExtension:
+                          description: validateExtension references an extension which
+                            is called to validate the topology.
+                          type: string
+                      type: object
+                    name:
+                      description: name of the patch.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              variables:
+                description: |-
+                  variables defines the variables which can be configured
+                  in the Cluster topology and are then used in patches.
+                items:
+                  description: |-
+                    ClusterClassVariable defines a variable which can
+                    be configured in the Cluster topology and used in patches.
+                  properties:
+                    metadata:
+                      description: |-
+                        metadata is the metadata of a variable.
+                        It can be used to add additional data for higher level tools to
+                        a ClusterClassVariable.
+
+                        Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please use XMetadata in JSONSchemaProps instead.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            annotations is an unstructured key value map that can be used to store and
+                            retrieve arbitrary metadata.
+                            They are not queryable.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) variables.
+                          type: object
+                      type: object
+                    name:
+                      description: name of the variable.
+                      type: string
+                    required:
+                      description: |-
+                        required specifies if the variable is required.
+                        Note: this applies to the variable as a whole and thus the
+                        top-level object defined in the schema. If nested fields are
+                        required, this will be specified inside the schema.
+                      type: boolean
+                    schema:
+                      description: schema defines the schema of the variable.
+                      properties:
+                        openAPIV3Schema:
+                          description: |-
+                            openAPIV3Schema defines the schema of a variable via OpenAPI v3
+                            schema. The schema is a subset of the schema used in
+                            Kubernetes CRDs.
+                          properties:
+                            additionalProperties:
+                              description: |-
+                                additionalProperties specifies the schema of values in a map (keys are always strings).
+                                NOTE: Can only be set if type is object.
+                                NOTE: AdditionalProperties is mutually exclusive with Properties.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            allOf:
+                              description: |-
+                                allOf specifies that the variable must validate against all of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            anyOf:
+                              description: |-
+                                anyOf specifies that the variable must validate against one or more of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            default:
+                              description: |-
+                                default is the default value of the variable.
+                                NOTE: Can be set for all types.
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: description is a human-readable description
+                                of this variable.
+                              type: string
+                            enum:
+                              description: |-
+                                enum is the list of valid values of the variable.
+                                NOTE: Can be set for all types.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            example:
+                              description: example is an example for this variable.
+                              x-kubernetes-preserve-unknown-fields: true
+                            exclusiveMaximum:
+                              description: |-
+                                exclusiveMaximum specifies if the Maximum is exclusive.
+                                NOTE: Can only be set if type is integer or number.
+                              type: boolean
+                            exclusiveMinimum:
+                              description: |-
+                                exclusiveMinimum specifies if the Minimum is exclusive.
+                                NOTE: Can only be set if type is integer or number.
+                              type: boolean
+                            format:
+                              description: |-
+                                format is an OpenAPI v3 format string. Unknown formats are ignored.
+                                For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
+                                https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                NOTE: Can only be set if type is string.
+                              type: string
+                            items:
+                              description: |-
+                                items specifies fields of an array.
+                                NOTE: Can only be set if type is array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            maxItems:
+                              description: |-
+                                maxItems is the max length of an array variable.
+                                NOTE: Can only be set if type is array.
+                              format: int64
+                              type: integer
+                            maxLength:
+                              description: |-
+                                maxLength is the max length of a string variable.
+                                NOTE: Can only be set if type is string.
+                              format: int64
+                              type: integer
+                            maxProperties:
+                              description: |-
+                                maxProperties is the maximum amount of entries in a map or properties in an object.
+                                NOTE: Can only be set if type is object.
+                              format: int64
+                              type: integer
+                            maximum:
+                              description: |-
+                                maximum is the maximum of an integer or number variable.
+                                If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
+                                If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
+                                NOTE: Can only be set if type is integer or number.
+                              format: int64
+                              type: integer
+                            minItems:
+                              description: |-
+                                minItems is the min length of an array variable.
+                                NOTE: Can only be set if type is array.
+                              format: int64
+                              type: integer
+                            minLength:
+                              description: |-
+                                minLength is the min length of a string variable.
+                                NOTE: Can only be set if type is string.
+                              format: int64
+                              type: integer
+                            minProperties:
+                              description: |-
+                                minProperties is the minimum amount of entries in a map or properties in an object.
+                                NOTE: Can only be set if type is object.
+                              format: int64
+                              type: integer
+                            minimum:
+                              description: |-
+                                minimum is the minimum of an integer or number variable.
+                                If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
+                                If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
+                                NOTE: Can only be set if type is integer or number.
+                              format: int64
+                              type: integer
+                            not:
+                              description: |-
+                                not specifies that the variable must not validate against the subschema.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            oneOf:
+                              description: |-
+                                oneOf specifies that the variable must validate against exactly one of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            pattern:
+                              description: |-
+                                pattern is the regex which a string variable must match.
+                                NOTE: Can only be set if type is string.
+                              type: string
+                            properties:
+                              description: |-
+                                properties specifies fields of an object.
+                                NOTE: Can only be set if type is object.
+                                NOTE: Properties is mutually exclusive with AdditionalProperties.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            required:
+                              description: |-
+                                required specifies which fields of an object are required.
+                                NOTE: Can only be set if type is object.
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: |-
+                                type is the type of the variable.
+                                Valid values are: object, array, string, integer, number or boolean.
+                              type: string
+                            uniqueItems:
+                              description: |-
+                                uniqueItems specifies if items in an array must be unique.
+                                NOTE: Can only be set if type is array.
+                              type: boolean
+                            x-kubernetes-int-or-string:
+                              description: |-
+                                x-kubernetes-int-or-string specifies that this value is
+                                either an integer or a string. If this is true, an empty
+                                type is allowed and type as child of anyOf is permitted
+                                if following one of the following patterns:
+
+                                1) anyOf:
+                                   - type: integer
+                                   - type: string
+                                2) allOf:
+                                   - anyOf:
+                                     - type: integer
+                                     - type: string
+                                   - ... zero or more
+                              type: boolean
+                            x-kubernetes-preserve-unknown-fields:
+                              description: |-
+                                x-kubernetes-preserve-unknown-fields allows setting fields in a variable object
+                                which are not defined in the variable schema. This affects fields recursively,
+                                except if nested properties or additionalProperties are specified in the schema.
+                              type: boolean
+                            x-kubernetes-validations:
+                              description: x-kubernetes-validations describes a list
+                                of validation rules written in the CEL expression
+                                language.
+                              items:
+                                description: ValidationRule describes a validation
+                                  rule written in the CEL expression language.
+                                properties:
+                                  fieldPath:
+                                    description: |-
+                                      fieldPath represents the field path returned when the validation fails.
+                                      It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field.
+                                      e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo`
+                                      If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList`
+                                      It does not support list numeric index.
+                                      It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info.
+                                      Numeric index of array is not supported.
+                                      For field name which contains special characters, use `['specialName']` to refer the field name.
+                                      e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+                                    type: string
+                                  message:
+                                    description: |-
+                                      message represents the message displayed when validation fails. The message is required if the Rule contains
+                                      line breaks. The message must not contain line breaks.
+                                      If unset, the message is "failed rule: {Rule}".
+                                      e.g. "must be a URL with the host matching spec.host"
+                                    type: string
+                                  messageExpression:
+                                    description: |-
+                                      messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+                                      Since messageExpression is used as a failure message, it must evaluate to a string.
+                                      If both message and messageExpression are present on a rule, then messageExpression will be used if validation
+                                      fails. If messageExpression results in a runtime error, the validation failure message is produced
+                                      as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string
+                                      that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset.
+                                      messageExpression has access to all the same variables as the rule; the only difference is the return type.
+                                      Example:
+                                      "x must be less than max ("+string(self.max)+")"
+                                    type: string
+                                  reason:
+                                    default: FieldValueInvalid
+                                    description: |-
+                                      reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule.
+                                      The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate".
+                                      If not set, default to use "FieldValueInvalid".
+                                      All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+                                    enum:
+                                    - FieldValueInvalid
+                                    - FieldValueForbidden
+                                    - FieldValueRequired
+                                    - FieldValueDuplicate
+                                    type: string
+                                  rule:
+                                    description: "rule represents the expression which
+                                      will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nThe
+                                      Rule is scoped to the location of the x-kubernetes-validations
+                                      extension in the schema.\nThe `self` variable
+                                      in the CEL expression is bound to the scoped
+                                      value.\nIf the Rule is scoped to an object with
+                                      properties, the accessible properties of the
+                                      object are field selectable\nvia `self.field`
+                                      and field presence can be checked via `has(self.field)`.\nIf
+                                      the Rule is scoped to an object with additionalProperties
+                                      (i.e. a map) the value of the map\nare accessible
+                                      via `self[mapKey]`, map containment can be checked
+                                      via `mapKey in self` and all entries of the
+                                      map\nare accessible via CEL macros and functions
+                                      such as `self.all(...)`.\nIf the Rule is scoped
+                                      to an array, the elements of the array are accessible
+                                      via `self[i]` and also by macros and\nfunctions.\nIf
+                                      the Rule is scoped to a scalar, `self` is bound
+                                      to the scalar value.\nExamples:\n- Rule scoped
+                                      to a map of objects: {\"rule\": \"self.components['Widget'].priority
+                                      < 10\"}\n- Rule scoped to a list of integers:
+                                      {\"rule\": \"self.values.all(value, value >=
+                                      0 && value < 100)\"}\n- Rule scoped to a string
+                                      value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown
+                                      data preserved in custom resources via x-kubernetes-preserve-unknown-fields
+                                      is not accessible in CEL\nexpressions. This
+                                      includes:\n- Unknown field values that are preserved
+                                      by object schemas with x-kubernetes-preserve-unknown-fields.\n-
+                                      Object properties where the property schema
+                                      is of an \"unknown type\". An \"unknown type\"
+                                      is recursively defined as:\n  - A schema with
+                                      no type and x-kubernetes-preserve-unknown-fields
+                                      set to true\n  - An array where the items schema
+                                      is of an \"unknown type\"\n  - An object where
+                                      the additionalProperties schema is of an \"unknown
+                                      type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`
+                                      are accessible.\nAccessible property names are
+                                      escaped according to the following rules when
+                                      accessed in the expression:\n- '__' escapes
+                                      to '__underscores__'\n- '.' escapes to '__dot__'\n-
+                                      '-' escapes to '__dash__'\n- '/' escapes to
+                                      '__slash__'\n- Property names that exactly match
+                                      a CEL RESERVED keyword escape to '__{keyword}__'.
+                                      The keywords are:\n\t  \"true\", \"false\",
+                                      \"null\", \"in\", \"as\", \"break\", \"const\",
+                                      \"continue\", \"else\", \"for\", \"function\",
+                                      \"if\",\n\t  \"import\", \"let\", \"loop\",
+                                      \"package\", \"namespace\", \"return\".\nExamples:\n
+                                      \ - Rule accessing a property named \"namespace\":
+                                      {\"rule\": \"self.__namespace__ > 0\"}\n  -
+                                      Rule accessing a property named \"x-prop\":
+                                      {\"rule\": \"self.x__dash__prop > 0\"}\n  -
+                                      Rule accessing a property named \"redact__d\":
+                                      {\"rule\": \"self.redact__underscores__d > 0\"}\n\nIf
+                                      `rule` makes use of the `oldSelf` variable it
+                                      is implicitly a\n`transition rule`.\n\nBy default,
+                                      the `oldSelf` variable is the same type as `self`.\n\nTransition
+                                      rules by default are applied only on UPDATE
+                                      requests and are\nskipped if an old value could
+                                      not be found."
+                                    type: string
+                                required:
+                                - rule
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - rule
+                              x-kubernetes-list-type: map
+                            x-metadata:
+                              description: |-
+                                x-metadata is the metadata of a variable or a nested field within a variable.
+                                It can be used to add additional data for higher level tools.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map that can be used to store and
+                                    retrieve arbitrary metadata.
+                                    They are not queryable.
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) variables.
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                      - openAPIV3Schema
+                      type: object
+                  required:
+                  - name
+                  - required
+                  - schema
+                  type: object
+                type: array
+              workers:
+                description: |-
+                  workers describes the worker nodes for the cluster.
+                  It is a collection of node types which can be used to create
+                  the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: |-
+                      machineDeployments is a list of machine deployment classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster
+                        provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of worker node present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachineDeployment.
+                          type: string
+                        failureDomain:
+                          description: |-
+                            failureDomain is the failure domain the machines will be created in.
+                            Must match a key in the FailureDomains map stored on the cluster object.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        machineHealthCheck:
+                          description: machineHealthCheck defines a MachineHealthCheck
+                            for this MachineDeploymentClass.
+                          properties:
+                            maxUnhealthy:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                                "selector" are not healthy.
+                              x-kubernetes-int-or-string: true
+                            nodeStartupTimeout:
+                              description: |-
+                                nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                to consider a Machine unhealthy if a corresponding Node isn't associated
+                                through a `Spec.ProviderID` field.
+
+                                The duration set in this field is compared to the greatest of:
+                                - Cluster's infrastructure ready condition timestamp (if and when available)
+                                - Control Plane's initialized condition timestamp (if and when available)
+                                - Machine's infrastructure ready condition timestamp (if and when available)
+                                - Machine's metadata creation timestamp
+
+                                Defaults to 10 minutes.
+                                If you wish to disable this feature, set the value explicitly to 0.
+                              type: string
+                            remediationTemplate:
+                              description: |-
+                                remediationTemplate is a reference to a remediation template
+                                provided by an infrastructure provider.
+
+                                This field is completely optional, when filled, the MachineHealthCheck controller
+                                creates a new object from the template referenced and hands off remediation of the machine to
+                                a controller that lives outside of Cluster API.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: |-
+                                    If referring to a piece of an object instead of an entire object, this string
+                                    should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                    For example, if the object reference is to a container within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                    the event) or if no container name is specified "spec.containers[2]" (container with
+                                    index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                    referencing a part of an object.
+                                  type: string
+                                kind:
+                                  description: |-
+                                    Kind of the referent.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                  type: string
+                                resourceVersion:
+                                  description: |-
+                                    Specific resourceVersion to which this reference is made, if any.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                  type: string
+                                uid:
+                                  description: |-
+                                    UID of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            unhealthyConditions:
+                              description: |-
+                                unhealthyConditions contains a list of the conditions that determine
+                                whether a node is considered unhealthy. The conditions are combined in a
+                                logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                              items:
+                                description: |-
+                                  UnhealthyCondition represents a Node condition type and value with a timeout
+                                  specified as a duration.  When the named condition has been in the given
+                                  status for at least the timeout value, a node is considered unhealthy.
+                                properties:
+                                  status:
+                                    minLength: 1
+                                    type: string
+                                  timeout:
+                                    type: string
+                                  type:
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - status
+                                - timeout
+                                - type
+                                type: object
+                              type: array
+                            unhealthyRange:
+                              description: |-
+                                Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                                Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                (a) there are at least 3 unhealthy machines (and)
+                                (b) there are at most 5 unhealthy machines
+                              pattern: ^\[[0-9]+-[0-9]+\]$
+                              type: string
+                          type: object
+                        minReadySeconds:
+                          description: |-
+                            Minimum number of seconds for which a newly created machine should
+                            be ready.
+                            Defaults to 0 (machine will be considered available as soon as it
+                            is ready)
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          format: int32
+                          type: integer
+                        namingStrategy:
+                          description: namingStrategy allows changing the naming pattern
+                            used when creating the MachineDeployment.
+                          properties:
+                            template:
+                              description: |-
+                                template defines the template to use for generating the name of the MachineDeployment object.
+                                If not defined, it will fallback to `{{ .cluster.name }}-{{ .machineDeployment.topologyName }}-{{ .random }}`.
+                                If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                                get concatenated with a random suffix of length 5.
+                                The templating mechanism provides the following arguments:
+                                * `.cluster.name`: The name of the cluster object.
+                                * `.random`: A random alphanumeric string, without vowels, of length 5.
+                                * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).
+                              type: string
+                          type: object
+                        nodeDeletionTimeout:
+                          description: |-
+                            nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                            hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                            Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        nodeDrainTimeout:
+                          description: |-
+                            nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                            The default value is 0, meaning that the node can be drained without any time limitations.
+                            NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: |-
+                            nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                            to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        strategy:
+                          description: |-
+                            The deployment strategy to use to replace existing machines with
+                            new ones.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          properties:
+                            remediation:
+                              description: |-
+                                remediation controls the strategy of remediating unhealthy machines
+                                and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                              properties:
+                                maxInFlight:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                    Remediation only happens on the MachineSet with the most current revision, while
+                                    older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                    Note: In general (independent of remediations), unhealthy machines are always
+                                    prioritized during scale down operations over healthy ones.
+
+                                    MaxInFlight can be set to a fixed number or a percentage.
+                                    Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                    the desired replicas.
+
+                                    If not set, remediation is limited to all machines (bounded by replicas)
+                                    under the active MachineSet's management.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            rollingUpdate:
+                              description: |-
+                                Rolling update config params. Present only if
+                                MachineDeploymentStrategyType = RollingUpdate.
+                              properties:
+                                deletePolicy:
+                                  description: |-
+                                    deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                    Valid values are "Random, "Newest", "Oldest"
+                                    When no value is supplied, the default DeletePolicy of MachineSet is used
+                                  enum:
+                                  - Random
+                                  - Newest
+                                  - Oldest
+                                  type: string
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    The maximum number of machines that can be scheduled above the
+                                    desired number of machines.
+                                    Value can be an absolute number (ex: 5) or a percentage of
+                                    desired machines (ex: 10%).
+                                    This can not be 0 if MaxUnavailable is 0.
+                                    Absolute number is calculated from percentage by rounding up.
+                                    Defaults to 1.
+                                    Example: when this is set to 30%, the new MachineSet can be scaled
+                                    up immediately when the rolling update starts, such that the total
+                                    number of old and new machines do not exceed 130% of desired
+                                    machines. Once old machines have been killed, new MachineSet can
+                                    be scaled up further, ensuring that total number of machines running
+                                    at any time during the update is at most 130% of desired machines.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    The maximum number of machines that can be unavailable during the update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired
+                                    machines (ex: 10%).
+                                    Absolute number is calculated from percentage by rounding down.
+                                    This can not be 0 if MaxSurge is 0.
+                                    Defaults to 0.
+                                    Example: when this is set to 30%, the old MachineSet can be scaled
+                                    down to 70% of desired machines immediately when the rolling update
+                                    starts. Once new machines are ready, old MachineSet can be scaled
+                                    down further, followed by scaling up the new MachineSet, ensuring
+                                    that the total number of machines available at all times
+                                    during the update is at least 70% of desired machines.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: |-
+                                type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                The default is RollingUpdate.
+                              enum:
+                              - RollingUpdate
+                              - OnDelete
+                              type: string
+                          type: object
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - class
+                    x-kubernetes-list-type: map
+                  machinePools:
+                    description: |-
+                      machinePools is a list of machine pool classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachinePoolClass serves as a template to define a pool of worker nodes of the cluster
+                        provisioned using `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of machine pool present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachinePool.
+                          type: string
+                        failureDomains:
+                          description: |-
+                            failureDomains is the list of failure domains the MachinePool should be attached to.
+                            Must match a key in the FailureDomains map stored on the cluster object.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          items:
+                            type: string
+                          type: array
+                        minReadySeconds:
+                          description: |-
+                            Minimum number of seconds for which a newly created machine pool should
+                            be ready.
+                            Defaults to 0 (machine will be considered available as soon as it
+                            is ready)
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          format: int32
+                          type: integer
+                        namingStrategy:
+                          description: namingStrategy allows changing the naming pattern
+                            used when creating the MachinePool.
+                          properties:
+                            template:
+                              description: |-
+                                template defines the template to use for generating the name of the MachinePool object.
+                                If not defined, it will fallback to `{{ .cluster.name }}-{{ .machinePool.topologyName }}-{{ .random }}`.
+                                If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                                get concatenated with a random suffix of length 5.
+                                The templating mechanism provides the following arguments:
+                                * `.cluster.name`: The name of the cluster object.
+                                * `.random`: A random alphanumeric string, without vowels, of length 5.
+                                * `.machinePool.topologyName`: The name of the MachinePool topology (Cluster.spec.topology.workers.machinePools[].name).
+                              type: string
+                          type: object
+                        nodeDeletionTimeout:
+                          description: |-
+                            nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                            hosts after the Machine Pool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                            Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        nodeDrainTimeout:
+                          description: |-
+                            nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                            The default value is 0, meaning that the node can be drained without any time limitations.
+                            NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: |-
+                            nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                            to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachinePools objects representing a pool of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of the Machines in the MachinePool.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of the MachinePool.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachinePool.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - class
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+          status:
+            description: ClusterClassStatus defines the observed state of the ClusterClass.
+            properties:
+              conditions:
+                description: conditions defines current observed state of the ClusterClass.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ClusterClass's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ClusterClass's current state.
+                      Known condition types are VariablesReady, RefVersionsUpToDate, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+              variables:
+                description: variables is a list of ClusterClassStatusVariable that
+                  are defined for the ClusterClass.
+                items:
+                  description: ClusterClassStatusVariable defines a variable which
+                    appears in the status of a ClusterClass.
+                  properties:
+                    definitions:
+                      description: definitions is a list of definitions for a variable.
+                      items:
+                        description: ClusterClassStatusVariableDefinition defines
+                          a variable which appears in the status of a ClusterClass.
+                        properties:
+                          from:
+                            description: |-
+                              from specifies the origin of the variable definition.
+                              This will be `inline` for variables defined in the ClusterClass or the name of a patch defined in the ClusterClass
+                              for variables discovered from a DiscoverVariables runtime extensions.
+                            type: string
+                          metadata:
+                            description: |-
+                              metadata is the metadata of a variable.
+                              It can be used to add additional data for higher level tools to
+                              a ClusterClassVariable.
+
+                              Deprecated: This field is deprecated and is going to be removed in the next apiVersion.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map that can be used to store and
+                                  retrieve arbitrary metadata.
+                                  They are not queryable.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) variables.
+                                type: object
+                            type: object
+                          required:
+                            description: |-
+                              required specifies if the variable is required.
+                              Note: this applies to the variable as a whole and thus the
+                              top-level object defined in the schema. If nested fields are
+                              required, this will be specified inside the schema.
+                            type: boolean
+                          schema:
+                            description: schema defines the schema of the variable.
+                            properties:
+                              openAPIV3Schema:
+                                description: |-
+                                  openAPIV3Schema defines the schema of a variable via OpenAPI v3
+                                  schema. The schema is a subset of the schema used in
+                                  Kubernetes CRDs.
+                                properties:
+                                  additionalProperties:
+                                    description: |-
+                                      additionalProperties specifies the schema of values in a map (keys are always strings).
+                                      NOTE: Can only be set if type is object.
+                                      NOTE: AdditionalProperties is mutually exclusive with Properties.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  allOf:
+                                    description: |-
+                                      allOf specifies that the variable must validate against all of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  anyOf:
+                                    description: |-
+                                      anyOf specifies that the variable must validate against one or more of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  default:
+                                    description: |-
+                                      default is the default value of the variable.
+                                      NOTE: Can be set for all types.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: description is a human-readable description
+                                      of this variable.
+                                    type: string
+                                  enum:
+                                    description: |-
+                                      enum is the list of valid values of the variable.
+                                      NOTE: Can be set for all types.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  example:
+                                    description: example is an example for this variable.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  exclusiveMaximum:
+                                    description: |-
+                                      exclusiveMaximum specifies if the Maximum is exclusive.
+                                      NOTE: Can only be set if type is integer or number.
+                                    type: boolean
+                                  exclusiveMinimum:
+                                    description: |-
+                                      exclusiveMinimum specifies if the Minimum is exclusive.
+                                      NOTE: Can only be set if type is integer or number.
+                                    type: boolean
+                                  format:
+                                    description: |-
+                                      format is an OpenAPI v3 format string. Unknown formats are ignored.
+                                      For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
+                                      https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                      NOTE: Can only be set if type is string.
+                                    type: string
+                                  items:
+                                    description: |-
+                                      items specifies fields of an array.
+                                      NOTE: Can only be set if type is array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  maxItems:
+                                    description: |-
+                                      maxItems is the max length of an array variable.
+                                      NOTE: Can only be set if type is array.
+                                    format: int64
+                                    type: integer
+                                  maxLength:
+                                    description: |-
+                                      maxLength is the max length of a string variable.
+                                      NOTE: Can only be set if type is string.
+                                    format: int64
+                                    type: integer
+                                  maxProperties:
+                                    description: |-
+                                      maxProperties is the maximum amount of entries in a map or properties in an object.
+                                      NOTE: Can only be set if type is object.
+                                    format: int64
+                                    type: integer
+                                  maximum:
+                                    description: |-
+                                      maximum is the maximum of an integer or number variable.
+                                      If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
+                                      If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
+                                      NOTE: Can only be set if type is integer or number.
+                                    format: int64
+                                    type: integer
+                                  minItems:
+                                    description: |-
+                                      minItems is the min length of an array variable.
+                                      NOTE: Can only be set if type is array.
+                                    format: int64
+                                    type: integer
+                                  minLength:
+                                    description: |-
+                                      minLength is the min length of a string variable.
+                                      NOTE: Can only be set if type is string.
+                                    format: int64
+                                    type: integer
+                                  minProperties:
+                                    description: |-
+                                      minProperties is the minimum amount of entries in a map or properties in an object.
+                                      NOTE: Can only be set if type is object.
+                                    format: int64
+                                    type: integer
+                                  minimum:
+                                    description: |-
+                                      minimum is the minimum of an integer or number variable.
+                                      If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
+                                      If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
+                                      NOTE: Can only be set if type is integer or number.
+                                    format: int64
+                                    type: integer
+                                  not:
+                                    description: |-
+                                      not specifies that the variable must not validate against the subschema.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  oneOf:
+                                    description: |-
+                                      oneOf specifies that the variable must validate against exactly one of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  pattern:
+                                    description: |-
+                                      pattern is the regex which a string variable must match.
+                                      NOTE: Can only be set if type is string.
+                                    type: string
+                                  properties:
+                                    description: |-
+                                      properties specifies fields of an object.
+                                      NOTE: Can only be set if type is object.
+                                      NOTE: Properties is mutually exclusive with AdditionalProperties.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                    description: |-
+                                      required specifies which fields of an object are required.
+                                      NOTE: Can only be set if type is object.
+                                    items:
+                                      type: string
+                                    type: array
+                                  type:
+                                    description: |-
+                                      type is the type of the variable.
+                                      Valid values are: object, array, string, integer, number or boolean.
+                                    type: string
+                                  uniqueItems:
+                                    description: |-
+                                      uniqueItems specifies if items in an array must be unique.
+                                      NOTE: Can only be set if type is array.
+                                    type: boolean
+                                  x-kubernetes-int-or-string:
+                                    description: |-
+                                      x-kubernetes-int-or-string specifies that this value is
+                                      either an integer or a string. If this is true, an empty
+                                      type is allowed and type as child of anyOf is permitted
+                                      if following one of the following patterns:
+
+                                      1) anyOf:
+                                         - type: integer
+                                         - type: string
+                                      2) allOf:
+                                         - anyOf:
+                                           - type: integer
+                                           - type: string
+                                         - ... zero or more
+                                    type: boolean
+                                  x-kubernetes-preserve-unknown-fields:
+                                    description: |-
+                                      x-kubernetes-preserve-unknown-fields allows setting fields in a variable object
+                                      which are not defined in the variable schema. This affects fields recursively,
+                                      except if nested properties or additionalProperties are specified in the schema.
+                                    type: boolean
+                                  x-kubernetes-validations:
+                                    description: x-kubernetes-validations describes
+                                      a list of validation rules written in the CEL
+                                      expression language.
+                                    items:
+                                      description: ValidationRule describes a validation
+                                        rule written in the CEL expression language.
+                                      properties:
+                                        fieldPath:
+                                          description: |-
+                                            fieldPath represents the field path returned when the validation fails.
+                                            It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field.
+                                            e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo`
+                                            If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList`
+                                            It does not support list numeric index.
+                                            It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info.
+                                            Numeric index of array is not supported.
+                                            For field name which contains special characters, use `['specialName']` to refer the field name.
+                                            e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+                                          type: string
+                                        message:
+                                          description: |-
+                                            message represents the message displayed when validation fails. The message is required if the Rule contains
+                                            line breaks. The message must not contain line breaks.
+                                            If unset, the message is "failed rule: {Rule}".
+                                            e.g. "must be a URL with the host matching spec.host"
+                                          type: string
+                                        messageExpression:
+                                          description: |-
+                                            messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+                                            Since messageExpression is used as a failure message, it must evaluate to a string.
+                                            If both message and messageExpression are present on a rule, then messageExpression will be used if validation
+                                            fails. If messageExpression results in a runtime error, the validation failure message is produced
+                                            as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string
+                                            that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset.
+                                            messageExpression has access to all the same variables as the rule; the only difference is the return type.
+                                            Example:
+                                            "x must be less than max ("+string(self.max)+")"
+                                          type: string
+                                        reason:
+                                          default: FieldValueInvalid
+                                          description: |-
+                                            reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule.
+                                            The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate".
+                                            If not set, default to use "FieldValueInvalid".
+                                            All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+                                          enum:
+                                          - FieldValueInvalid
+                                          - FieldValueForbidden
+                                          - FieldValueRequired
+                                          - FieldValueDuplicate
+                                          type: string
+                                        rule:
+                                          description: "rule represents the expression
+                                            which will be evaluated by CEL.\nref:
+                                            https://github.com/google/cel-spec\nThe
+                                            Rule is scoped to the location of the
+                                            x-kubernetes-validations extension in
+                                            the schema.\nThe `self` variable in the
+                                            CEL expression is bound to the scoped
+                                            value.\nIf the Rule is scoped to an object
+                                            with properties, the accessible properties
+                                            of the object are field selectable\nvia
+                                            `self.field` and field presence can be
+                                            checked via `has(self.field)`.\nIf the
+                                            Rule is scoped to an object with additionalProperties
+                                            (i.e. a map) the value of the map\nare
+                                            accessible via `self[mapKey]`, map containment
+                                            can be checked via `mapKey in self` and
+                                            all entries of the map\nare accessible
+                                            via CEL macros and functions such as `self.all(...)`.\nIf
+                                            the Rule is scoped to an array, the elements
+                                            of the array are accessible via `self[i]`
+                                            and also by macros and\nfunctions.\nIf
+                                            the Rule is scoped to a scalar, `self`
+                                            is bound to the scalar value.\nExamples:\n-
+                                            Rule scoped to a map of objects: {\"rule\":
+                                            \"self.components['Widget'].priority <
+                                            10\"}\n- Rule scoped to a list of integers:
+                                            {\"rule\": \"self.values.all(value, value
+                                            >= 0 && value < 100)\"}\n- Rule scoped
+                                            to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown
+                                            data preserved in custom resources via
+                                            x-kubernetes-preserve-unknown-fields is
+                                            not accessible in CEL\nexpressions. This
+                                            includes:\n- Unknown field values that
+                                            are preserved by object schemas with x-kubernetes-preserve-unknown-fields.\n-
+                                            Object properties where the property schema
+                                            is of an \"unknown type\". An \"unknown
+                                            type\" is recursively defined as:\n  -
+                                            A schema with no type and x-kubernetes-preserve-unknown-fields
+                                            set to true\n  - An array where the items
+                                            schema is of an \"unknown type\"\n  -
+                                            An object where the additionalProperties
+                                            schema is of an \"unknown type\"\n\nOnly
+                                            property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`
+                                            are accessible.\nAccessible property names
+                                            are escaped according to the following
+                                            rules when accessed in the expression:\n-
+                                            '__' escapes to '__underscores__'\n- '.'
+                                            escapes to '__dot__'\n- '-' escapes to
+                                            '__dash__'\n- '/' escapes to '__slash__'\n-
+                                            Property names that exactly match a CEL
+                                            RESERVED keyword escape to '__{keyword}__'.
+                                            The keywords are:\n\t  \"true\", \"false\",
+                                            \"null\", \"in\", \"as\", \"break\", \"const\",
+                                            \"continue\", \"else\", \"for\", \"function\",
+                                            \"if\",\n\t  \"import\", \"let\", \"loop\",
+                                            \"package\", \"namespace\", \"return\".\nExamples:\n
+                                            \ - Rule accessing a property named \"namespace\":
+                                            {\"rule\": \"self.__namespace__ > 0\"}\n
+                                            \ - Rule accessing a property named \"x-prop\":
+                                            {\"rule\": \"self.x__dash__prop > 0\"}\n
+                                            \ - Rule accessing a property named \"redact__d\":
+                                            {\"rule\": \"self.redact__underscores__d
+                                            > 0\"}\n\nIf `rule` makes use of the `oldSelf`
+                                            variable it is implicitly a\n`transition
+                                            rule`.\n\nBy default, the `oldSelf` variable
+                                            is the same type as `self`.\n\nTransition
+                                            rules by default are applied only on UPDATE
+                                            requests and are\nskipped if an old value
+                                            could not be found."
+                                          type: string
+                                      required:
+                                      - rule
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - rule
+                                    x-kubernetes-list-type: map
+                                  x-metadata:
+                                    description: |-
+                                      x-metadata is the metadata of a variable or a nested field within a variable.
+                                      It can be used to add additional data for higher level tools.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          annotations is an unstructured key value map that can be used to store and
+                                          retrieve arbitrary metadata.
+                                          They are not queryable.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Map of string keys and values that can be used to organize and categorize
+                                          (scope and select) variables.
+                                        type: object
+                                    type: object
+                                type: object
+                            required:
+                            - openAPIV3Schema
+                            type: object
+                        required:
+                        - from
+                        - required
+                        - schema
+                        type: object
+                      type: array
+                    definitionsConflict:
+                      description: definitionsConflict specifies whether or not there
+                        are conflicting definitions for a single variable name.
+                      type: boolean
+                    name:
+                      description: name is the name of the variable.
+                      type: string
+                  required:
+                  - definitions
+                  - name
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSetBinding
+    listKind: ClusterResourceSetBindingList
+    plural: clusterresourcesetbindings
+    singular: clusterresourcesetbinding
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+              clusterName:
+                description: |-
+                  clusterName is the name of the Cluster this binding applies to.
+                  Note: this field mandatory in v1beta2.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSet
+    listKind: ClusterResourceSetList
+    plural: clusterresourcesets
+    singular: clusterresourceset
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSet is the Schema for the clusterresourcesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  Label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSet is the Schema for the clusterresourcesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  Label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                  Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  Label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                  Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                - Reconcile
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ClusterResourceSet's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ClusterResourceSet's current state.
+                      Known condition types are ResourceSetApplied, Deleting.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusters.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneInitialized:
+                description: controlPlaneInitialized defines if the control plane
+                  has been initialized.
+                type: boolean
+              controlPlaneReady:
+                description: controlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Cluster is the Schema for the clusters API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: |-
+                  This encapsulates the topology for the cluster.
+                  NOTE: It is required to enable the ClusterTopology
+                  feature gate flag to activate managed topologies support;
+                  this feature is highly experimental, and parts of it might still be not implemented.
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the
+                      topology.
+                    type: string
+                  controlPlane:
+                    description: controlPlane describes the cluster control plane.
+                    properties:
+                      metadata:
+                        description: |-
+                          metadata is the metadata applied to the machines of the ControlPlane.
+                          At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+
+                          This field is supported if and only if the control plane provider template
+                          referenced in the ClusterClass is Machine based.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      replicas:
+                        description: |-
+                          replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created without the number of Replicas
+                          and it's assumed that the control plane controller does not implement support for this field.
+                          When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: |-
+                      rolloutAfter performs a rollout of the entire cluster one component at a time,
+                      control plane first and then machine deployments.
+                    format: date-time
+                    type: string
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: |-
+                      workers encapsulates the different constructs that form the worker nodes
+                      for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: machineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: |-
+                            MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachineDeploymentClass used to create the set of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachineDeploymentTopology.
+                                The value is used with other unique identifiers to create a MachineDeployment's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              type: string
+                            replicas:
+                              description: |-
+                                replicas is the number of worker nodes belonging to this set.
+                                If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: controlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: ClusterClass of this Cluster, empty if the Cluster is not using
+        a ClusterClass
+      jsonPath: .spec.topology.class
+      name: ClusterClass
+      type: string
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Cluster
+      jsonPath: .spec.topology.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              availabilityGates:
+                description: |-
+                  availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                  NOTE: this field is considered only for computing v1beta2 conditions.
+                items:
+                  description: ClusterAvailabilityGate contains the type of a Cluster
+                    condition to be used as availability gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a positive polarity condition (status true means good) with matching type in the Cluster's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: |-
+                  This encapsulates the topology for the cluster.
+                  NOTE: It is required to enable the ClusterTopology
+                  feature gate flag to activate managed topologies support;
+                  this feature is highly experimental, and parts of it might still be not implemented.
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the
+                      topology.
+                    type: string
+                  classNamespace:
+                    description: |-
+                      classNamespace is the namespace of the ClusterClass object to create the topology.
+                      If the namespace is empty or not set, it is defaulted to the namespace of the cluster object.
+                      Value must follow the DNS1123Subdomain syntax.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  controlPlane:
+                    description: controlPlane describes the cluster control plane.
+                    properties:
+                      machineHealthCheck:
+                        description: |-
+                          machineHealthCheck allows to enable, disable and override
+                          the MachineHealthCheck configuration in the ClusterClass for this control plane.
+                        properties:
+                          enable:
+                            description: |-
+                              enable controls if a MachineHealthCheck should be created for the target machines.
+
+                              If false: No MachineHealthCheck will be created.
+
+                              If not set(default): A MachineHealthCheck will be created if it is defined here or
+                               in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                              If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                              block if `enable` is true and no MachineHealthCheck definition is available.
+                            type: boolean
+                          maxUnhealthy:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                              "selector" are not healthy.
+                            x-kubernetes-int-or-string: true
+                          nodeStartupTimeout:
+                            description: |-
+                              nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                              to consider a Machine unhealthy if a corresponding Node isn't associated
+                              through a `Spec.ProviderID` field.
+
+                              The duration set in this field is compared to the greatest of:
+                              - Cluster's infrastructure ready condition timestamp (if and when available)
+                              - Control Plane's initialized condition timestamp (if and when available)
+                              - Machine's infrastructure ready condition timestamp (if and when available)
+                              - Machine's metadata creation timestamp
+
+                              Defaults to 10 minutes.
+                              If you wish to disable this feature, set the value explicitly to 0.
+                            type: string
+                          remediationTemplate:
+                            description: |-
+                              remediationTemplate is a reference to a remediation template
+                              provided by an infrastructure provider.
+
+                              This field is completely optional, when filled, the MachineHealthCheck controller
+                              creates a new object from the template referenced and hands off remediation of the machine to
+                              a controller that lives outside of Cluster API.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          unhealthyConditions:
+                            description: |-
+                              unhealthyConditions contains a list of the conditions that determine
+                              whether a node is considered unhealthy. The conditions are combined in a
+                              logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                            items:
+                              description: |-
+                                UnhealthyCondition represents a Node condition type and value with a timeout
+                                specified as a duration.  When the named condition has been in the given
+                                status for at least the timeout value, a node is considered unhealthy.
+                              properties:
+                                status:
+                                  minLength: 1
+                                  type: string
+                                timeout:
+                                  type: string
+                                type:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - status
+                              - timeout
+                              - type
+                              type: object
+                            type: array
+                          unhealthyRange:
+                            description: |-
+                              Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                              is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                              Eg. "[3-5]" - This means that remediation will be allowed only when:
+                              (a) there are at least 3 unhealthy machines (and)
+                              (b) there are at most 5 unhealthy machines
+                            pattern: ^\[[0-9]+-[0-9]+\]$
+                            type: string
+                        type: object
+                      metadata:
+                        description: |-
+                          metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                          if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it
+                          is applied only to the ControlPlane.
+                          At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      replicas:
+                        description: |-
+                          replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created without the number of Replicas
+                          and it's assumed that the control plane controller does not implement support for this field.
+                          When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                      variables:
+                        description: variables can be used to customize the ControlPlane
+                          through patches.
+                        properties:
+                          overrides:
+                            description: overrides can be used to override Cluster
+                              level variables.
+                            items:
+                              description: |-
+                                ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                Variable definition in the ClusterClass `status` variables.
+                              properties:
+                                definitionFrom:
+                                  description: |-
+                                    definitionFrom specifies where the definition of this Variable is from.
+
+                                    Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                  type: string
+                                name:
+                                  description: name of the variable.
+                                  type: string
+                                value:
+                                  description: |-
+                                    value of the variable.
+                                    Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                    from the ClusterClass.
+                                    Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                    hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                    i.e. it is not possible to have no type field.
+                                    Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                    type: object
+                  rolloutAfter:
+                    description: |-
+                      rolloutAfter performs a rollout of the entire cluster one component at a time,
+                      control plane first and then machine deployments.
+
+                      Deprecated: This field has no function and is going to be removed in the next apiVersion.
+                    format: date-time
+                    type: string
+                  variables:
+                    description: |-
+                      variables can be used to customize the Cluster through
+                      patches. They must comply to the corresponding
+                      VariableClasses defined in the ClusterClass.
+                    items:
+                      description: |-
+                        ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                        Variable definition in the ClusterClass `status` variables.
+                      properties:
+                        definitionFrom:
+                          description: |-
+                            definitionFrom specifies where the definition of this Variable is from.
+
+                            Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                          type: string
+                        name:
+                          description: name of the variable.
+                          type: string
+                        value:
+                          description: |-
+                            value of the variable.
+                            Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                            from the ClusterClass.
+                            Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                            hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                            i.e. it is not possible to have no type field.
+                            Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: |-
+                      workers encapsulates the different constructs that form the worker nodes
+                      for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: machineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: |-
+                            MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachineDeploymentClass used to create the set of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            failureDomain:
+                              description: |-
+                                failureDomain is the failure domain the machines will be created in.
+                                Must match a key in the FailureDomains map stored on the cluster object.
+                              type: string
+                            machineHealthCheck:
+                              description: |-
+                                machineHealthCheck allows to enable, disable and override
+                                the MachineHealthCheck configuration in the ClusterClass for this MachineDeployment.
+                              properties:
+                                enable:
+                                  description: |-
+                                    enable controls if a MachineHealthCheck should be created for the target machines.
+
+                                    If false: No MachineHealthCheck will be created.
+
+                                    If not set(default): A MachineHealthCheck will be created if it is defined here or
+                                     in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                                    If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                                    block if `enable` is true and no MachineHealthCheck definition is available.
+                                  type: boolean
+                                maxUnhealthy:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                                    "selector" are not healthy.
+                                  x-kubernetes-int-or-string: true
+                                nodeStartupTimeout:
+                                  description: |-
+                                    nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                    to consider a Machine unhealthy if a corresponding Node isn't associated
+                                    through a `Spec.ProviderID` field.
+
+                                    The duration set in this field is compared to the greatest of:
+                                    - Cluster's infrastructure ready condition timestamp (if and when available)
+                                    - Control Plane's initialized condition timestamp (if and when available)
+                                    - Machine's infrastructure ready condition timestamp (if and when available)
+                                    - Machine's metadata creation timestamp
+
+                                    Defaults to 10 minutes.
+                                    If you wish to disable this feature, set the value explicitly to 0.
+                                  type: string
+                                remediationTemplate:
+                                  description: |-
+                                    remediationTemplate is a reference to a remediation template
+                                    provided by an infrastructure provider.
+
+                                    This field is completely optional, when filled, the MachineHealthCheck controller
+                                    creates a new object from the template referenced and hands off remediation of the machine to
+                                    a controller that lives outside of Cluster API.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                unhealthyConditions:
+                                  description: |-
+                                    unhealthyConditions contains a list of the conditions that determine
+                                    whether a node is considered unhealthy. The conditions are combined in a
+                                    logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                                  items:
+                                    description: |-
+                                      UnhealthyCondition represents a Node condition type and value with a timeout
+                                      specified as a duration.  When the named condition has been in the given
+                                      status for at least the timeout value, a node is considered unhealthy.
+                                    properties:
+                                      status:
+                                        minLength: 1
+                                        type: string
+                                      timeout:
+                                        type: string
+                                      type:
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - status
+                                    - timeout
+                                    - type
+                                    type: object
+                                  type: array
+                                unhealthyRange:
+                                  description: |-
+                                    Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                    is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                                    Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                    (a) there are at least 3 unhealthy machines (and)
+                                    (b) there are at most 5 unhealthy machines
+                                  pattern: ^\[[0-9]+-[0-9]+\]$
+                                  type: string
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: |-
+                                Minimum number of seconds for which a newly created machine should
+                                be ready.
+                                Defaults to 0 (machine will be considered available as soon as it
+                                is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachineDeploymentTopology.
+                                The value is used with other unique identifiers to create a MachineDeployment's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              type: string
+                            nodeDeletionTimeout:
+                              description: |-
+                                nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                                hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: |-
+                                nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                                The default value is 0, meaning that the node can be drained without any time limitations.
+                                NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: |-
+                                nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              type: string
+                            replicas:
+                              description: |-
+                                replicas is the number of worker nodes belonging to this set.
+                                If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            strategy:
+                              description: |-
+                                The deployment strategy to use to replace existing machines with
+                                new ones.
+                              properties:
+                                remediation:
+                                  description: |-
+                                    remediation controls the strategy of remediating unhealthy machines
+                                    and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                                  properties:
+                                    maxInFlight:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                        Remediation only happens on the MachineSet with the most current revision, while
+                                        older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                        Note: In general (independent of remediations), unhealthy machines are always
+                                        prioritized during scale down operations over healthy ones.
+
+                                        MaxInFlight can be set to a fixed number or a percentage.
+                                        Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                        the desired replicas.
+
+                                        If not set, remediation is limited to all machines (bounded by replicas)
+                                        under the active MachineSet's management.
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                rollingUpdate:
+                                  description: |-
+                                    Rolling update config params. Present only if
+                                    MachineDeploymentStrategyType = RollingUpdate.
+                                  properties:
+                                    deletePolicy:
+                                      description: |-
+                                        deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                        Valid values are "Random, "Newest", "Oldest"
+                                        When no value is supplied, the default DeletePolicy of MachineSet is used
+                                      enum:
+                                      - Random
+                                      - Newest
+                                      - Oldest
+                                      type: string
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        The maximum number of machines that can be scheduled above the
+                                        desired number of machines.
+                                        Value can be an absolute number (ex: 5) or a percentage of
+                                        desired machines (ex: 10%).
+                                        This can not be 0 if MaxUnavailable is 0.
+                                        Absolute number is calculated from percentage by rounding up.
+                                        Defaults to 1.
+                                        Example: when this is set to 30%, the new MachineSet can be scaled
+                                        up immediately when the rolling update starts, such that the total
+                                        number of old and new machines do not exceed 130% of desired
+                                        machines. Once old machines have been killed, new MachineSet can
+                                        be scaled up further, ensuring that total number of machines running
+                                        at any time during the update is at most 130% of desired machines.
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        The maximum number of machines that can be unavailable during the update.
+                                        Value can be an absolute number (ex: 5) or a percentage of desired
+                                        machines (ex: 10%).
+                                        Absolute number is calculated from percentage by rounding down.
+                                        This can not be 0 if MaxSurge is 0.
+                                        Defaults to 0.
+                                        Example: when this is set to 30%, the old MachineSet can be scaled
+                                        down to 70% of desired machines immediately when the rolling update
+                                        starts. Once new machines are ready, old MachineSet can be scaled
+                                        down further, followed by scaling up the new MachineSet, ensuring
+                                        that the total number of machines available at all times
+                                        during the update is at least 70% of desired machines.
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  description: |-
+                                    type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                    The default is RollingUpdate.
+                                  enum:
+                                  - RollingUpdate
+                                  - OnDelete
+                                  type: string
+                              type: object
+                            variables:
+                              description: variables can be used to customize the
+                                MachineDeployment through patches.
+                              properties:
+                                overrides:
+                                  description: overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: |-
+                                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                      Variable definition in the ClusterClass `status` variables.
+                                    properties:
+                                      definitionFrom:
+                                        description: |-
+                                          definitionFrom specifies where the definition of this Variable is from.
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        type: string
+                                      name:
+                                        description: name of the variable.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value of the variable.
+                                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass.
+                                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                          i.e. it is not possible to have no type field.
+                                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      machinePools:
+                        description: machinePools is a list of machine pools in the
+                          cluster.
+                        items:
+                          description: |-
+                            MachinePoolTopology specifies the different parameters for a pool of worker nodes in the topology.
+                            This pool of nodes is managed by a MachinePool object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachinePoolClass used to create the pool of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            failureDomains:
+                              description: |-
+                                failureDomains is the list of failure domains the machine pool will be created in.
+                                Must match a key in the FailureDomains map stored on the cluster object.
+                              items:
+                                type: string
+                              type: array
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachinePool.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: |-
+                                Minimum number of seconds for which a newly created machine pool should
+                                be ready.
+                                Defaults to 0 (machine will be considered available as soon as it
+                                is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachinePoolTopology.
+                                The value is used with other unique identifiers to create a MachinePool's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              type: string
+                            nodeDeletionTimeout:
+                              description: |-
+                                nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the MachinePool
+                                hosts after the MachinePool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: |-
+                                nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                                The default value is 0, meaning that the node can be drained without any time limitations.
+                                NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: |-
+                                nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              type: string
+                            replicas:
+                              description: |-
+                                replicas is the number of nodes belonging to this pool.
+                                If the value is nil, the MachinePool is created without the number of Replicas (defaulting to 1)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            variables:
+                              description: variables can be used to customize the
+                                MachinePool through patches.
+                              properties:
+                                overrides:
+                                  description: overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: |-
+                                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                      Variable definition in the ClusterClass `status` variables.
+                                    properties:
+                                      definitionFrom:
+                                        description: |-
+                                          definitionFrom specifies where the definition of this Variable is from.
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        type: string
+                                      name:
+                                        description: name of the variable.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value of the variable.
+                                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass.
+                                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                          i.e. it is not possible to have no type field.
+                                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: |-
+                  controlPlaneReady denotes if the control plane became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in Cluster's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a Cluster's current state.
+                      Known condition types are Available, InfrastructureReady, ControlPlaneInitialized, ControlPlaneAvailable, WorkersAvailable, MachinesReady
+                      MachinesUpToDate, RemoteConnectionProbe, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                      Additionally, a TopologyReconciled condition will be added in case the Cluster is referencing a ClusterClass / defining a managed Topology.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  controlPlane:
+                    description: controlPlane groups all the observations about Cluster's
+                      ControlPlane current state.
+                    properties:
+                      availableReplicas:
+                        description: availableReplicas is the total number of available
+                          control plane machines in this cluster. A machine is considered
+                          available when Machine's Available condition is true.
+                        format: int32
+                        type: integer
+                      desiredReplicas:
+                        description: desiredReplicas is the total number of desired
+                          control plane machines in this cluster.
+                        format: int32
+                        type: integer
+                      readyReplicas:
+                        description: readyReplicas is the total number of ready control
+                          plane machines in this cluster. A machine is considered
+                          ready when Machine's Ready condition is true.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: |-
+                          replicas is the total number of control plane machines in this cluster.
+                          NOTE: replicas also includes machines still being provisioned or being deleted.
+                        format: int32
+                        type: integer
+                      upToDateReplicas:
+                        description: upToDateReplicas is the number of up-to-date
+                          control plane machines in this cluster. A machine is considered
+                          up-to-date when Machine's UpToDate condition is true.
+                        format: int32
+                        type: integer
+                    type: object
+                  workers:
+                    description: workers groups all the observations about Cluster's
+                      Workers current state.
+                    properties:
+                      availableReplicas:
+                        description: availableReplicas is the total number of available
+                          worker machines in this cluster. A machine is considered
+                          available when Machine's Available condition is true.
+                        format: int32
+                        type: integer
+                      desiredReplicas:
+                        description: desiredReplicas is the total number of desired
+                          worker machines in this cluster.
+                        format: int32
+                        type: integer
+                      readyReplicas:
+                        description: readyReplicas is the total number of ready worker
+                          machines in this cluster. A machine is considered ready
+                          when Machine's Ready condition is true.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: |-
+                          replicas is the total number of worker machines in this cluster.
+                          NOTE: replicas also includes machines still being provisioned or being deleted.
+                        format: int32
+                        type: integer
+                      upToDateReplicas:
+                        description: upToDateReplicas is the number of up-to-date
+                          worker machines in this cluster. A machine is considered
+                          up-to-date when Machine's UpToDate condition is true.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: extensionconfigs.runtime.cluster.x-k8s.io
+spec:
+  group: runtime.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ExtensionConfig
+    listKind: ExtensionConfigList
+    plural: extensionconfigs
+    shortNames:
+    - ext
+    singular: extensionconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ExtensionConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ExtensionConfig is the Schema for the ExtensionConfig API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ExtensionConfigSpec is the desired state of the ExtensionConfig
+            properties:
+              clientConfig:
+                description: clientConfig defines how to communicate with the Extension
+                  server.
+                properties:
+                  caBundle:
+                    description: caBundle is a PEM encoded CA bundle which will be
+                      used to validate the Extension server's server certificate.
+                    format: byte
+                    type: string
+                  service:
+                    description: |-
+                      service is a reference to the Kubernetes service for the Extension server.
+                      Note: Exactly one of `url` or `service` must be specified.
+
+                      If the Extension server is running within a cluster, then you should use `service`.
+                    properties:
+                      name:
+                        description: name is the name of the service.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the service.
+                        type: string
+                      path:
+                        description: |-
+                          path is an optional URL path and if present may be any string permissible in
+                          a URL. If a path is set it will be used as prefix to the hook-specific path.
+                        type: string
+                      port:
+                        description: |-
+                          port is the port on the service that's hosting the Extension server.
+                          Defaults to 443.
+                          Port should be a valid port number (1-65535, inclusive).
+                        format: int32
+                        type: integer
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  url:
+                    description: |-
+                      url gives the location of the Extension server, in standard URL form
+                      (`scheme://host:port/path`).
+                      Note: Exactly one of `url` or `service` must be specified.
+
+                      The scheme must be "https".
+
+                      The `host` should not refer to a service running in the cluster; use
+                      the `service` field instead.
+
+                      A path is optional, and if present may be any string permissible in
+                      a URL. If a path is set it will be used as prefix to the hook-specific path.
+
+                      Attempting to use a user or basic auth e.g. "user:password@" is not
+                      allowed. Fragments ("#...") and query parameters ("?...") are not
+                      allowed either.
+                    type: string
+                type: object
+              namespaceSelector:
+                description: |-
+                  namespaceSelector decides whether to call the hook for an object based
+                  on whether the namespace for that object matches the selector.
+                  Defaults to the empty LabelSelector, which matches all objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              settings:
+                additionalProperties:
+                  type: string
+                description: |-
+                  settings defines key value pairs to be passed to all calls
+                  to all supported RuntimeExtensions.
+                  Note: Settings can be overridden on the ClusterClass.
+                type: object
+            required:
+            - clientConfig
+            type: object
+          status:
+            description: ExtensionConfigStatus is the current state of the ExtensionConfig
+            properties:
+              conditions:
+                description: conditions define the current service state of the ExtensionConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              handlers:
+                description: handlers defines the current ExtensionHandlers supported
+                  by an Extension.
+                items:
+                  description: ExtensionHandler specifies the details of a handler
+                    for a particular runtime hook registered by an Extension server.
+                  properties:
+                    failurePolicy:
+                      description: |-
+                        failurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.
+                        Defaults to Fail if not set.
+                      type: string
+                    name:
+                      description: name is the unique name of the ExtensionHandler.
+                      type: string
+                    requestHook:
+                      description: requestHook defines the versioned runtime hook
+                        which this ExtensionHandler serves.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the group and version of the
+                            Hook.
+                          type: string
+                        hook:
+                          description: hook is the name of the hook.
+                          type: string
+                      required:
+                      - apiVersion
+                      - hook
+                      type: object
+                    timeoutSeconds:
+                      description: |-
+                        timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.
+                        Defaults to 10 is not set.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - requestHook
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: ipaddressclaims.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddressClaim
+    listKind: IPAddressClaimList
+    plural: ipaddressclaims
+    singular: ipaddressclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdressClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressClaimSpec is the desired state of an IPAddressClaim.
+            properties:
+              poolRef:
+                description: poolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - poolRef
+            type: object
+          status:
+            description: IPAddressClaimStatus is the observed status of a IPAddressClaim.
+            properties:
+              addressRef:
+                description: addressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdressClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressClaimSpec is the desired state of an IPAddressClaim.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - poolRef
+            type: object
+          status:
+            description: IPAddressClaimStatus is the observed status of a IPAddressClaim.
+            properties:
+              addressRef:
+                description: addressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: ipaddresses.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddress
+    listKind: IPAddressList
+    plural: ipaddresses
+    singular: ipaddress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressSpec is the desired state of an IPAddress.
+            properties:
+              address:
+                description: address is the IP address.
+                type: string
+              claimRef:
+                description: claimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              gateway:
+                description: gateway is the network gateway of the network the address
+                  is from.
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressSpec is the desired state of an IPAddress.
+            properties:
+              address:
+                description: address is the IP address.
+                type: string
+              claimRef:
+                description: claimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              gateway:
+                description: gateway is the network gateway of the network the address
+                  is from.
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineDeployment is the Schema for the machinedeployments API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: |-
+                  Minimum number of seconds for which a newly created machine should
+                  be ready.
+                  Defaults to 0 (machine will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  The maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  The deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          generateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          List of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.Data without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: |-
+                              data contains the bootstrap data, such as cloud-init details scripts.
+                              If nil, the Machine should remain in the Pending state.
+
+                              Deprecated: Switch to DataSecretName.
+                            type: string
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  Total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineDeployment is the Schema for the machinedeployments API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: |-
+                  Minimum number of seconds for which a newly created machine should
+                  be ready.
+                  Defaults to 0 (machine will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  The maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: |-
+                  Number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  The deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: |-
+                          deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                          Valid values are "Random, "Newest", "Oldest"
+                          When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment.
+                      Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  Total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachineDeployment
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineDeployment
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
+                  Defaults to 0 (machine will be considered available as soon as the Node is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  The maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/11470 for more details.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Number of desired machines.
+                  This is a pointer to distinguish between explicit zero and not specified.
+
+                  Defaults to:
+                  * if the Kubernetes autoscaler min size and max size annotations are set:
+                    - if it's a new MachineDeployment, use min size
+                    - if the replicas field of the old MachineDeployment is < min size, use min size
+                    - if the replicas field of the old MachineDeployment is > max size, use max size
+                    - if the replicas field of the old MachineDeployment is in the (min size, max size) range, keep the value from the oldMD
+                  * otherwise use 1
+                  Note: Defaulting will be run whenever the replicas field is not set:
+                  * A new MachineDeployment is created with replicas not set.
+                  * On an existing MachineDeployment the replicas field was first set and is now unset.
+                  Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+                  * A new MachineDeployment is created and replicas should be managed by the autoscaler
+                  * An existing MachineDeployment which initially wasn't controlled by the autoscaler
+                    should be later controlled by the autoscaler
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10479 for more details.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: |-
+                  rolloutAfter is a field to indicate a rollout should be performed
+                  after the specified time even if no changes have been made to the
+                  MachineDeployment.
+                  Example: In the YAML the time can be specified in the RFC3339 format.
+                  To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                  use "2023-03-09T09:00:00Z".
+                format: date-time
+                type: string
+              selector:
+                description: |-
+                  Label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  The deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  remediation:
+                    description: |-
+                      remediation controls the strategy of remediating unhealthy machines
+                      and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                    properties:
+                      maxInFlight:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxInFlight determines how many in flight remediations should happen at the same time.
+
+                          Remediation only happens on the MachineSet with the most current revision, while
+                          older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                          Note: In general (independent of remediations), unhealthy machines are always
+                          prioritized during scale down operations over healthy ones.
+
+                          MaxInFlight can be set to a fixed number or a percentage.
+                          Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                          the desired replicas.
+
+                          If not set, remediation is limited to all machines (bounded by replicas)
+                          under the active MachineSet's management.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: |-
+                          deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                          Valid values are "Random, "Newest", "Oldest"
+                          When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Allowed values are RollingUpdate and OnDelete.
+                      The default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  Total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineDeployment's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachineDeployment. A machine is considered available
+                      when Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineDeployment's current state.
+                      Known condition types are Available, MachinesReady, MachinesUpToDate, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachineDeployment. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this deployment. A machine is considered up-to-date
+                      when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinedrainrules.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDrainRule
+    listKind: MachineDrainRuleList
+    plural: machinedrainrules
+    singular: machinedrainrule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Drain behavior
+      jsonPath: .spec.drain.behavior
+      name: Behavior
+      type: string
+    - description: Drain order
+      jsonPath: .spec.drain.order
+      name: Order
+      type: string
+    - description: Time duration since creation of the MachineDrainRule
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDrainRule is the Schema for the MachineDrainRule API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the spec of a MachineDrainRule.
+            properties:
+              drain:
+                description: drain configures if and how Pods are drained.
+                properties:
+                  behavior:
+                    description: |-
+                      behavior defines the drain behavior.
+                      Can be either "Drain", "Skip", or "WaitCompleted".
+                      "Drain" means that the Pods to which this MachineDrainRule applies will be drained.
+                      If behavior is set to "Drain" the order in which Pods are drained can be configured
+                      with the order field. When draining Pods of a Node the Pods will be grouped by order
+                      and one group after another will be drained (by increasing order). Cluster API will
+                      wait until all Pods of a group are terminated / removed from the Node before starting
+                      with the next group.
+                      "Skip" means that the Pods to which this MachineDrainRule applies will be skipped during drain.
+                      "WaitCompleted" means that the pods to which this MachineDrainRule applies will never be evicted
+                      and we wait for them to be completed, it is enforced that pods marked with this behavior always have Order=0.
+                    enum:
+                    - Drain
+                    - Skip
+                    - WaitCompleted
+                    type: string
+                  order:
+                    description: |-
+                      order defines the order in which Pods are drained.
+                      Pods with higher order are drained after Pods with lower order.
+                      order can only be set if behavior is set to "Drain".
+                      If order is not set, 0 will be used.
+                      Valid values for order are from -2147483648 to 2147483647 (inclusive).
+                    format: int32
+                    type: integer
+                required:
+                - behavior
+                type: object
+              machines:
+                description: |-
+                  machines defines to which Machines this MachineDrainRule should be applied.
+
+                  If machines is not set, the MachineDrainRule applies to all Machines in the Namespace.
+                  If machines contains multiple selectors, the results are ORed.
+                  Within a single Machine selector the results of selector and clusterSelector are ANDed.
+                  Machines will be selected from all Clusters in the Namespace unless otherwise
+                  restricted with the clusterSelector.
+
+                  Example: Selects control plane Machines in all Clusters or
+                           Machines with label "os" == "linux" in Clusters with label
+                           "stage" == "production".
+
+                   - selector:
+                       matchExpressions:
+                       - key: cluster.x-k8s.io/control-plane
+                         operator: Exists
+                   - selector:
+                       matchLabels:
+                         os: linux
+                     clusterSelector:
+                       matchExpressions:
+                       - key: stage
+                         operator: In
+                         values:
+                         - production
+                items:
+                  description: MachineDrainRuleMachineSelector defines to which Machines
+                    this MachineDrainRule should be applied.
+                  minProperties: 1
+                  properties:
+                    clusterSelector:
+                      description: |-
+                        clusterSelector is a label selector which selects Machines by the labels of
+                        their Clusters.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects Machines of all Clusters.
+
+                        If selector is also set, then the selector as a whole selects
+                        Machines matching selector belonging to Clusters selected by clusterSelector.
+                        If selector is not set, it selects all Machines belonging to Clusters
+                        selected by clusterSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: |-
+                        selector is a label selector which selects Machines by their labels.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects all Machines.
+
+                        If clusterSelector is also set, then the selector as a whole selects
+                        Machines matching selector belonging to Clusters selected by clusterSelector.
+                        If clusterSelector is not set, it selects all Machines matching selector in
+                        all Clusters.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              pods:
+                description: |-
+                  pods defines to which Pods this MachineDrainRule should be applied.
+
+                  If pods is not set, the MachineDrainRule applies to all Pods in all Namespaces.
+                  If pods contains multiple selectors, the results are ORed.
+                  Within a single Pod selector the results of selector and namespaceSelector are ANDed.
+                  Pods will be selected from all Namespaces unless otherwise
+                  restricted with the namespaceSelector.
+
+                  Example: Selects Pods with label "app" == "logging" in all Namespaces or
+                           Pods with label "app" == "prometheus" in the "monitoring"
+                           Namespace.
+
+                   - selector:
+                       matchExpressions:
+                       - key: app
+                         operator: In
+                         values:
+                         - logging
+                   - selector:
+                       matchLabels:
+                         app: prometheus
+                     namespaceSelector:
+                       matchLabels:
+                         kubernetes.io/metadata.name: monitoring
+                items:
+                  description: MachineDrainRulePodSelector defines to which Pods this
+                    MachineDrainRule should be applied.
+                  minProperties: 1
+                  properties:
+                    namespaceSelector:
+                      description: |-
+                        namespaceSelector is a label selector which selects Pods by the labels of
+                        their Namespaces.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects Pods of all Namespaces.
+
+                        If selector is also set, then the selector as a whole selects
+                        Pods matching selector in Namespaces selected by namespaceSelector.
+                        If selector is not set, it selects all Pods in Namespaces selected by
+                        namespaceSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: |-
+                        selector is a label selector which selects Pods by their labels.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects all Pods.
+
+                        If namespaceSelector is also set, then the selector as a whole selects
+                        Pods matching selector in Namespaces selected by namespaceSelector.
+                        If namespaceSelector is not set, it selects all Pods matching selector in
+                        all Namespaces.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - drain
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinehealthchecks.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineHealthCheck
+    listKind: MachineHealthCheckList
+    plural: machinehealthchecks
+    shortNames:
+    - mhc
+    - mhcs
+    singular: machinehealthcheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineHealthCheck is the Schema for the machinehealthchecks API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                  "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  Machines older than this duration without a node will be considered to have
+                  failed and will be remediated.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: Label selector to match machines whose health will be
+                  exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine
+                  health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health
+                  check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineHealthCheck is the Schema for the machinehealthchecks API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                  "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  Machines older than this duration without a node will be considered to have
+                  failed and will be remediated.
+                  If not set, this value is defaulted to 10 minutes.
+                  If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: Label selector to match machines whose health will be
+                  exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: |-
+                  Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                  Eg. "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and)
+                  (b) there are at most 5 unhealthy machines
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine
+                  health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health
+                  check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                  "selector" are not healthy.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                  to consider a Machine unhealthy if a corresponding Node isn't associated
+                  through a `Spec.ProviderID` field.
+
+                  The duration set in this field is compared to the greatest of:
+                  - Cluster's infrastructure ready condition timestamp (if and when available)
+                  - Control Plane's initialized condition timestamp (if and when available)
+                  - Machine's infrastructure ready condition timestamp (if and when available)
+                  - Machine's metadata creation timestamp
+
+                  Defaults to 10 minutes.
+                  If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: Label selector to match machines whose health will be
+                  exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                type: array
+              unhealthyRange:
+                description: |-
+                  Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                  Eg. "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and)
+                  (b) there are at most 5 unhealthy machines
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine
+                  health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health
+                  check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineHealthCheck's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineHealthCheck's current state.
+                      Known condition types are RemediationAllowed, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinepools.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachinePool is the Schema for the machinepools API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: |-
+                  Minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              strategy:
+                description: |-
+                  The deployment strategy to use to replace existing machine instances with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          generateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          List of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.Data without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: |-
+                              data contains the bootstrap data, such as cloud-init details scripts.
+                              If nil, the Machine should remain in the Pending state.
+
+                              Deprecated: Switch to DataSecretName.
+                            type: string
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachinePool is the Schema for the machinepools API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: |-
+                  Minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachinePool
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: |-
+                  Minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachinePool's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachinePool. A machine is considered available when
+                      Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachinePool's current state.
+                      Known condition types are Available, BootstrapConfigReady, InfrastructureReady, MachinesReady, MachinesUpToDate,
+                      ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachinePool. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this MachinePool. A machine is considered up-to-date
+                      when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machines.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    shortNames:
+    - ma
+    singular: machine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Machine is the Schema for the machines API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.Data without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  data:
+                    description: |-
+                      data contains the bootstrap data, such as cloud-init details scripts.
+                      If nil, the Machine should remain in the Pending state.
+
+                      Deprecated: Switch to DataSecretName.
+                    type: string
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: |-
+                  version specifies the current version of Kubernetes running
+                  on the corresponding Node. This is meant to be a means of bubbling
+                  up status from the Node to the Machine.
+                  It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Machine is the Schema for the machines API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.DataSecretName without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: |-
+                  nodeInfo is a set of ids/uuids to uniquely identify the node.
+                  More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: 'Deprecated: KubeProxy Version reported by the node.'
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: |-
+                  version specifies the current version of Kubernetes running
+                  on the corresponding Node. This is meant to be a means of bubbling
+                  up status from the Node to the Machine.
+                  It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.DataSecretName without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDeletionTimeout:
+                description: |-
+                  nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                  hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                  Defaults to 10 seconds.
+                type: string
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              nodeVolumeDetachTimeout:
+                description: |-
+                  nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                  to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              readinessGates:
+                description: |-
+                  readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                  This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                  Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                  for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                  Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                  they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                  NOTE: This field is considered only for computing v1beta2 conditions.
+                  NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                  readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                  readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                  This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                items:
+                  description: MachineReadinessGate contains the type of a Machine
+                    condition to be used as a readiness gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              certificatesExpiryDate:
+                description: |-
+                  certificatesExpiryDate is the expiry date of the machine certificates.
+                  This value is only set for control plane machines.
+                format: date-time
+                type: string
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              deletion:
+                description: |-
+                  deletion contains information relating to removal of the Machine.
+                  Only present when the Machine has a deletionTimestamp and drain or wait for volume detach started.
+                properties:
+                  nodeDrainStartTime:
+                    description: |-
+                      nodeDrainStartTime is the time when the drain of the node started and is used to determine
+                      if the NodeDrainTimeout is exceeded.
+                      Only present when the Machine has a deletionTimestamp and draining the node had been started.
+                    format: date-time
+                    type: string
+                  waitForNodeVolumeDetachStartTime:
+                    description: |-
+                      waitForNodeVolumeDetachStartTime is the time when waiting for volume detachment started
+                      and is used to determine if the NodeVolumeDetachTimeout is exceeded.
+                      Detaching volumes from nodes is usually done by CSI implementations and the current state
+                      is observed from the node's `.Status.VolumesAttached` field.
+                      Only present when the Machine has a deletionTimestamp and waiting for volume detachments had been started.
+                    format: date-time
+                    type: string
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: |-
+                  nodeInfo is a set of ids/uuids to uniquely identify the node.
+                  More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: 'Deprecated: KubeProxy Version reported by the node.'
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in Machine's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a Machine's current state.
+                      Known condition types are Available, Ready, UpToDate, BootstrapConfigReady, InfrastructureReady, NodeReady,
+                      NodeHealthy, Deleting, Paused.
+                      If a MachineHealthCheck is targeting this machine, also HealthCheckSucceeded, OwnerRemediated conditions are added.
+                      Additionally control plane Machines controlled by KubeadmControlPlane will have following additional conditions:
+                      APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy, EtcdMemberHealthy.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinesets.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    shortNames:
+    - ms
+    singular: machineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineSet is the Schema for the machinesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine should be ready.
+                  Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          generateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          List of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.Data without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: |-
+                              data contains the bootstrap data, such as cloud-init details scripts.
+                              If nil, the Machine should remain in the Pending state.
+
+                              Deprecated: Switch to DataSecretName.
+                            type: string
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              failureMessage:
+                type: string
+              failureReason:
+                description: |-
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineSet is the Schema for the machinesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine should be ready.
+                  Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: |-
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this machineset
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineSet
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
+                  Defaults to 0 (machine will be considered available as soon as the Node is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+
+                  Defaults to:
+                  * if the Kubernetes autoscaler min size and max size annotations are set:
+                    - if it's a new MachineSet, use min size
+                    - if the replicas field of the old MachineSet is < min size, use min size
+                    - if the replicas field of the old MachineSet is > max size, use max size
+                    - if the replicas field of the old MachineSet is in the (min size, max size) range, keep the value from the oldMS
+                  * otherwise use 1
+                  Note: Defaulting will be run whenever the replicas field is not set:
+                  * A new MachineSet is created with replicas not set.
+                  * On an existing MachineSet the replicas field was first set and is now unset.
+                  Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+                  * A new MachineSet is created and replicas should be managed by the autoscaler
+                  * An existing MachineSet which initially wasn't controlled by the autoscaler
+                    should be later controlled by the autoscaler
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: 'Deprecated: This field is deprecated and is going to
+                  be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md
+                  for more details.'
+                type: string
+              failureReason:
+                description: |-
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              fullyLabeledReplicas:
+                description: |-
+                  The number of replicas that have labels matching the labels of the machine template of the MachineSet.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineSet's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachineSet. A machine is considered available when
+                      Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineSet's current state.
+                      Known condition types are MachinesReady, MachinesUpToDate, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachineSet. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      for this MachineSet. A machine is considered up-to-date when
+                      Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-leader-election-role
+  namespace: capi-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - clusterresourcesets/finalizers
+  - clusterresourcesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  - clusterclasses/status
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  - machinehealthchecks/finalizers
+  - machinehealthchecks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  - machinedeployments/status
+  - machinehealthchecks
+  - machinepools
+  - machinepools/finalizers
+  - machinepools/status
+  - machines
+  - machines/finalizers
+  - machines/status
+  - machinesets
+  - machinesets/finalizers
+  - machinesets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedrainrules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - runtime.cluster.x-k8s.io
+  resources:
+  - extensionconfigs
+  - extensionconfigs/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-leader-election-rolebinding
+  namespace: capi-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-webhook-service
+  namespace: capi-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: cluster-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    control-plane: controller-manager
+  name: capi-controller-manager
+  namespace: capi-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: cluster-api
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: cluster-api
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+        - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+        - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.6
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: capi-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-serving-cert
+  namespace: capi-system
+spec:
+  dnsNames:
+  - capi-webhook-service.capi-system.svc
+  - capi-webhook-service.capi-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-selfsigned-issuer
+  secretName: capi-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-selfsigned-issuer
+  namespace: capi-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.extensionconfig.runtime.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - runtime.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - extensionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedrainrule
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedrainrule.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedrainrules
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.extensionconfig.runtime.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - runtime.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - extensionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourcesetbinding
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourcesetbinding.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesetbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-ipam-cluster-x-k8s-io-v1beta1-ipaddress
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ipaddress.ipam.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - ipam.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddresses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-ipam-cluster-x-k8s-io-v1beta1-ipaddressclaim
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ipaddressclaim.ipam.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - ipam.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddressclaims
+  sideEffects: None

--- a/roles/cluster_api/files/providers/cluster-api/v1.9.6/metadata.yaml
+++ b/roles/cluster_api/files/providers/cluster-api/v1.9.6/metadata.yaml
@@ -1,0 +1,38 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 9
+    contract: v1beta1
+  - major: 1
+    minor: 8
+    contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1
+  - major: 1
+    minor: 6
+    contract: v1beta1
+  - major: 1
+    minor: 5
+    contract: v1beta1
+  - major: 1
+    minor: 4
+    contract: v1beta1
+  - major: 1
+    minor: 3
+    contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
+    minor: 0
+    contract: v1beta1

--- a/roles/cluster_api/files/providers/control-plane-kubeadm/v1.9.6/control-plane-components.yaml
+++ b/roles/cluster_api/files/providers/control-plane-kubeadm/v1.9.6/control-plane-components.yaml
@@ -1,0 +1,8242 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    control-plane: controller-manager
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlane
+    listKind: KubeadmControlPlaneList
+    plural: kubeadmcontrolplanes
+    shortNames:
+    - kcp
+    singular: kubeadmcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              infrastructureTemplate:
+                description: |-
+                  infrastructureTemplate is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              kubeadmConfigSpec:
+                description: |-
+                  kubeadmConfigSpec is a KubeadmConfigSpec
+                  to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: clusterConfiguration along with InitConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API
+                          server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout
+                              that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for
+                          the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          type:
+                            description: Type defines the DNS add-on to be used
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for
+                                  ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                          `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                          will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      useHyperKubeImage:
+                        description: UseHyperKubeImage controls if hyperkube should
+                          be used for Kubernetes components instead of their respective
+                          separate images
+                        type: boolean
+                    type: object
+                  diskSetup:
+                    description: diskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: filesystems specifies the list of file systems
+                          to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: extraOpts defined extra options to add
+                                to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: label specifies the file system label to
+                                be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any",
+                                "none", and <NUM>, where NUM is the actual partition
+                                number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: partitions specifies the list of the partitions
+                          to setup.
+                        items:
+                          description: Partition defines how to create and layout
+                            a partition.
+                          properties:
+                            device:
+                              description: device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                tableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files
+                        in cloud-init.
+                      properties:
+                        content:
+                          description: content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: contentFrom is a referenced source of content
+                            to populate the file.
+                          properties:
+                            secret:
+                              description: secret represents a secret that should
+                                populate this file.
+                              properties:
+                                key:
+                                  description: key is the key in the secret's data
+                                    map for this value.
+                                  type: string
+                                name:
+                                  description: name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: encoding specifies the encoding of the file
+                            contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: owner specifies the ownership of the file,
+                            e.g. "root:root".
+                          type: string
+                        path:
+                          description: path specifies the full path on disk where
+                            to store the file.
+                          type: string
+                        permissions:
+                          description: permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: format specifies the output format of the bootstrap
+                      data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: initConfiguration along with ClusterConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token,
+                            stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: joinConfiguration is the kubeadm configuration for
+                      the join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint
+                              of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                        type: object
+                      discovery:
+                        description: Discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain
+                                  name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            - unsafeSkipCAVerification
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the
+                                  actual file path or URL to the kubeconfig file from
+                                  which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts
+                        in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: ntp specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: postKubeadmCommands specifies extra commands to run
+                      after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: preKubeadmCommands specifies extra commands to run
+                      before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+                      This will add about 40KB to userdata
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                    type: boolean
+                  users:
+                    description: users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in
+                        cloud-init.
+                      properties:
+                        gecos:
+                          description: gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: groups specifies the additional groups for
+                            the user
+                          type: string
+                        homeDir:
+                          description: homeDir specifies the home directory to use
+                            for the user
+                          type: string
+                        inactive:
+                          description: inactive specifies whether to mark the user
+                            as inactive
+                          type: boolean
+                        lockPassword:
+                          description: lockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: name specifies the user name
+                          type: string
+                        passwd:
+                          description: passwd specifies a hashed password for the
+                            user
+                          type: string
+                        primaryGroup:
+                          description: primaryGroup specifies the primary group for
+                            the user
+                          type: string
+                        shell:
+                          description: shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: sshAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1. When stacked etcd is used only
+                  odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutStrategy:
+                description: |-
+                  The RolloutStrategy to use to replace control plane machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of control planes that can be scheduled above or under the
+                          desired number of control planes.
+                          Value can be an absolute number 1 or 0.
+                          Defaults to 1.
+                          Example: when this is set to 1, the control plane can be scaled
+                          up immediately when the rolling update starts.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of rollout. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              upgradeAfter:
+                description: |-
+                  upgradeAfter is a field to indicate an upgrade should be performed
+                  after the specified time even if no changes have been made to the
+                  KubeadmControlPlane
+                format: date-time
+                type: string
+              version:
+                description: version defines the desired Kubernetes version.
+                type: string
+            required:
+            - infrastructureTemplate
+            - kubeadmConfigSpec
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  ErrorMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              initialized:
+                description: |-
+                  initialized denotes whether or not the control plane has the
+                  uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: |-
+                  ready denotes that the KubeadmControlPlane API Server is ready to
+                  receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane
+                  machines.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              kubeadmConfigSpec:
+                description: |-
+                  kubeadmConfigSpec is a KubeadmConfigSpec
+                  to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: clusterConfiguration along with InitConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: apiServer contains extra settings for the API
+                          server control plane component
+                        properties:
+                          certSANs:
+                            description: certSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: timeoutForControlPlane controls the timeout
+                              that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          certificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: controllerManager contains extra settings for
+                          the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: dns defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              imageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              external describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  certFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: endpoints of etcd members. Required for
+                                  ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  keyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  dataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  extraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  imageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: peerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: serverCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: featureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          imageRepository sets the container registry to pull images from.
+                          If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                          `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                          will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          kubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: dnsDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              podSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              serviceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: diskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: filesystems specifies the list of file systems
+                          to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: extraOpts defined extra options to add
+                                to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: label specifies the file system label to
+                                be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any",
+                                "none", and <NUM>, where NUM is the actual partition
+                                number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: partitions specifies the list of the partitions
+                          to setup.
+                        items:
+                          description: Partition defines how to create and layout
+                            a partition.
+                          properties:
+                            device:
+                              description: device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                tableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files
+                        in cloud-init.
+                      properties:
+                        content:
+                          description: content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: contentFrom is a referenced source of content
+                            to populate the file.
+                          properties:
+                            secret:
+                              description: secret represents a secret that should
+                                populate this file.
+                              properties:
+                                key:
+                                  description: key is the key in the secret's data
+                                    map for this value.
+                                  type: string
+                                name:
+                                  description: name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: encoding specifies the encoding of the file
+                            contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: owner specifies the ownership of the file,
+                            e.g. "root:root".
+                          type: string
+                        path:
+                          description: path specifies the full path on disk where
+                            to store the file.
+                          type: string
+                        permissions:
+                          description: permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: format specifies the output format of the bootstrap
+                      data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: initConfiguration along with ClusterConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token,
+                            stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                ttl defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: advertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              bindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: criSocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: ignorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: joinConfiguration is the kubeadm configuration for
+                      the join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          caCertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                        type: string
+                      controlPlane:
+                        description: |-
+                          controlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: localAPIEndpoint represents the endpoint
+                              of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: advertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  bindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              bootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: apiServerEndpoint is an IP or domain
+                                  name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  caCertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  unsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: |-
+                              file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: kubeConfigPath is used to specify the
+                                  actual file path or URL to the kubeconfig file from
+                                  which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              tlsBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: criSocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: ignorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts
+                        in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: ntp specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: postKubeadmCommands specifies extra commands to run
+                      after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: preKubeadmCommands specifies extra commands to run
+                      before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+                      This will add about 40KB to userdata
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                    type: boolean
+                  users:
+                    description: users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in
+                        cloud-init.
+                      properties:
+                        gecos:
+                          description: gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: groups specifies the additional groups for
+                            the user
+                          type: string
+                        homeDir:
+                          description: homeDir specifies the home directory to use
+                            for the user
+                          type: string
+                        inactive:
+                          description: inactive specifies whether to mark the user
+                            as inactive
+                          type: boolean
+                        lockPassword:
+                          description: lockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: name specifies the user name
+                          type: string
+                        passwd:
+                          description: passwd specifies a hashed password for the
+                            user
+                          type: string
+                        primaryGroup:
+                          description: primaryGroup specifies the primary group for
+                            the user
+                          type: string
+                        shell:
+                          description: shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: sshAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineTemplate:
+                description: |-
+                  machineTemplate contains information about how machines
+                  should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: |-
+                      infrastructureRef is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  nodeDrainTimeout:
+                    description: |-
+                      nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1. When stacked etcd is used only
+                  odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: |-
+                  rolloutAfter is a field to indicate a rollout should be performed
+                  after the specified time even if no changes have been made to the
+                  KubeadmControlPlane.
+                format: date-time
+                type: string
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: |-
+                  The RolloutStrategy to use to replace control plane machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of control planes that can be scheduled above or under the
+                          desired number of control planes.
+                          Value can be an absolute number 1 or 0.
+                          Defaults to 1.
+                          Example: when this is set to 1, the control plane can be scaled
+                          up immediately when the rolling update starts.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of rollout. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              version:
+                description: version defines the desired Kubernetes version.
+                type: string
+            required:
+            - kubeadmConfigSpec
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  ErrorMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              initialized:
+                description: |-
+                  initialized denotes whether or not the control plane has the
+                  uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: |-
+                  ready denotes that the KubeadmControlPlane API Server is ready to
+                  receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane
+                  machines.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: |-
+                  version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Total number of machines desired by this control plane
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              kubeadmConfigSpec:
+                description: |-
+                  kubeadmConfigSpec is a KubeadmConfigSpec
+                  to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: clusterConfiguration along with InitConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: apiServer contains extra settings for the API
+                          server control plane component
+                        properties:
+                          certSANs:
+                            description: certSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: timeoutForControlPlane controls the timeout
+                              that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          certificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: controllerManager contains extra settings for
+                          the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: dns defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              imageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              external describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  certFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: endpoints of etcd members. Required for
+                                  ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  keyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  dataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  extraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  imageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: peerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: serverCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: featureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          imageRepository sets the container registry to pull images from.
+                          * If not set, the default registry of kubeadm will be used, i.e.
+                            * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                            * k8s.gcr.io (old registry): all older versions
+                            Please note that when imageRepository is not set we don't allow upgrades to
+                            versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                            a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                            >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                          * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                           `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                            and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          kubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: dnsDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              podSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              serviceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: diskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: filesystems specifies the list of file systems
+                          to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: extraOpts defined extra options to add
+                                to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: label specifies the file system label to
+                                be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any",
+                                "none", and <NUM>, where NUM is the actual partition
+                                number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: partitions specifies the list of the partitions
+                          to setup.
+                        items:
+                          description: Partition defines how to create and layout
+                            a partition.
+                          properties:
+                            device:
+                              description: device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                tableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files
+                        in cloud-init.
+                      properties:
+                        append:
+                          description: append specifies whether to append Content
+                            to existing file if Path exists.
+                          type: boolean
+                        content:
+                          description: content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: contentFrom is a referenced source of content
+                            to populate the file.
+                          properties:
+                            secret:
+                              description: secret represents a secret that should
+                                populate this file.
+                              properties:
+                                key:
+                                  description: key is the key in the secret's data
+                                    map for this value.
+                                  type: string
+                                name:
+                                  description: name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: encoding specifies the encoding of the file
+                            contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: owner specifies the ownership of the file,
+                            e.g. "root:root".
+                          type: string
+                        path:
+                          description: path specifies the full path on disk where
+                            to store the file.
+                          type: string
+                        permissions:
+                          description: permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: format specifies the output format of the bootstrap
+                      data
+                    enum:
+                    - cloud-config
+                    - ignition
+                    type: string
+                  ignition:
+                    description: ignition contains Ignition specific configuration.
+                    properties:
+                      containerLinuxConfig:
+                        description: containerLinuxConfig contains CLC specific configuration.
+                        properties:
+                          additionalConfig:
+                            description: |-
+                              additionalConfig contains additional configuration to be merged with the Ignition
+                              configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                              The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                            type: string
+                          strict:
+                            description: strict controls if AdditionalConfig should
+                              be strictly parsed. If so, warnings are treated as errors.
+                            type: boolean
+                        type: object
+                    type: object
+                  initConfiguration:
+                    description: initConfiguration along with ClusterConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token,
+                            stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                ttl defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: advertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              bindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: criSocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: ignorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              type: string
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              imagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          imagePullSerial:
+                            description: |-
+                              imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                              Default: true (defaulted in kubeadm)
+                            type: boolean
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          skipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  joinConfiguration:
+                    description: joinConfiguration is the kubeadm configuration for
+                      the join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          caCertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                        type: string
+                      controlPlane:
+                        description: |-
+                          controlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: localAPIEndpoint represents the endpoint
+                              of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: advertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  bindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              bootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: apiServerEndpoint is an IP or domain
+                                  name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  caCertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  unsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: |-
+                              file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfig:
+                                description: |-
+                                  kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                  The file is generated at the path specified in KubeConfigPath.
+
+                                  Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                  Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                properties:
+                                  cluster:
+                                    description: |-
+                                      cluster contains information about how to communicate with the kubernetes cluster.
+
+                                      By default the following fields are automatically populated:
+                                      - Server with the Cluster's ControlPlaneEndpoint.
+                                      - CertificateAuthorityData with the Cluster's CA certificate.
+                                    properties:
+                                      certificateAuthorityData:
+                                        description: |-
+                                          certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                          Defaults to the Cluster's CA certificate if empty.
+                                        format: byte
+                                        type: string
+                                      insecureSkipTLSVerify:
+                                        description: insecureSkipTLSVerify skips the
+                                          validity check for the server's certificate.
+                                          This will make your HTTPS connections insecure.
+                                        type: boolean
+                                      proxyURL:
+                                        description: |-
+                                          proxyURL is the URL to the proxy to be used for all requests made by this
+                                          client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                          this configuration is not provided or the empty string, the client
+                                          attempts to construct a proxy configuration from http_proxy and
+                                          https_proxy environment variables. If these environment variables are not
+                                          set, the client does not attempt to proxy requests.
+
+                                          socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                          attach, port forward).
+                                        type: string
+                                      server:
+                                        description: |-
+                                          server is the address of the kubernetes cluster (https://hostname:port).
+
+                                          Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                        type: string
+                                      tlsServerName:
+                                        description: tlsServerName is used to check
+                                          server certificate. If TLSServerName is
+                                          empty, the hostname used to contact the
+                                          server is used.
+                                        type: string
+                                    type: object
+                                  user:
+                                    description: |-
+                                      user contains information that describes identity information.
+                                      This is used to tell the kubernetes cluster who you are.
+                                    properties:
+                                      authProvider:
+                                        description: authProvider specifies a custom
+                                          authentication plugin for the kubernetes
+                                          cluster.
+                                        properties:
+                                          config:
+                                            additionalProperties:
+                                              type: string
+                                            description: config holds the parameters
+                                              for the authentication plugin.
+                                            type: object
+                                          name:
+                                            description: name is the name of the authentication
+                                              plugin.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      exec:
+                                        description: exec specifies a custom exec-based
+                                          authentication plugin for the kubernetes
+                                          cluster.
+                                        properties:
+                                          apiVersion:
+                                            description: |-
+                                              Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                              the same encoding version as the input.
+                                              Defaults to client.authentication.k8s.io/v1 if not set.
+                                            type: string
+                                          args:
+                                            description: Arguments to pass to the
+                                              command when executing it.
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: command to execute.
+                                            type: string
+                                          env:
+                                            description: |-
+                                              env defines additional environment variables to expose to the process. These
+                                              are unioned with the host's environment, as well as variables client-go uses
+                                              to pass argument to the plugin.
+                                            items:
+                                              description: |-
+                                                KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                credential plugin.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          provideClusterInfo:
+                                            description: |-
+                                              provideClusterInfo determines whether or not to provide cluster information,
+                                              which could potentially contain very large CA data, to this exec plugin as a
+                                              part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                              to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                              reading this environment variable.
+                                            type: boolean
+                                        required:
+                                        - command
+                                        type: object
+                                    type: object
+                                required:
+                                - user
+                                type: object
+                              kubeConfigPath:
+                                description: kubeConfigPath is used to specify the
+                                  actual file path or URL to the kubeconfig file from
+                                  which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              tlsBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: criSocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: ignorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              type: string
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              imagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          imagePullSerial:
+                            description: |-
+                              imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                              Default: true (defaulted in kubeadm)
+                            type: boolean
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          skipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  mounts:
+                    description: mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts
+                        in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: ntp specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: postKubeadmCommands specifies extra commands to run
+                      after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: preKubeadmCommands specifies extra commands to run
+                      before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+                      This will add about 40KB to userdata
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                      Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                      When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                    type: boolean
+                  users:
+                    description: users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in
+                        cloud-init.
+                      properties:
+                        gecos:
+                          description: gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: groups specifies the additional groups for
+                            the user
+                          type: string
+                        homeDir:
+                          description: homeDir specifies the home directory to use
+                            for the user
+                          type: string
+                        inactive:
+                          description: inactive specifies whether to mark the user
+                            as inactive
+                          type: boolean
+                        lockPassword:
+                          description: lockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: name specifies the user name
+                          type: string
+                        passwd:
+                          description: passwd specifies a hashed password for the
+                            user
+                          type: string
+                        passwdFrom:
+                          description: passwdFrom is a referenced source of passwd
+                            to populate the passwd.
+                          properties:
+                            secret:
+                              description: secret represents a secret that should
+                                populate this password.
+                              properties:
+                                key:
+                                  description: key is the key in the secret's data
+                                    map for this value.
+                                  type: string
+                                name:
+                                  description: name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        primaryGroup:
+                          description: primaryGroup specifies the primary group for
+                            the user
+                          type: string
+                        shell:
+                          description: shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: sshAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineNamingStrategy:
+                description: |-
+                  MachineNamingStrategy allows changing the naming pattern used when creating Machines.
+                  InfraMachines & KubeadmConfigs will use the same name as the corresponding Machines.
+                properties:
+                  template:
+                    description: |-
+                      Template defines the template to use for generating the names of the Machine objects.
+                      If not defined, it will fallback to `{{ .kubeadmControlPlane.name }}-{{ .random }}`.
+                      If the generated name string exceeds 63 characters, it will be trimmed to 58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      Length of the template string must not exceed 256 characters.
+                      The template allows the following variables `.cluster.name`, `.kubeadmControlPlane.name` and `.random`.
+                      The variable `.cluster.name` retrieves the name of the cluster object that owns the Machines being created.
+                      The variable `.kubeadmControlPlane.name` retrieves the name of the KubeadmControlPlane object that owns the Machines being created.
+                      The variable `.random` is substituted with random alphanumeric string, without vowels, of length 5.
+                    maxLength: 256
+                    type: string
+                type: object
+              machineTemplate:
+                description: |-
+                  machineTemplate contains information about how machines
+                  should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: |-
+                      infrastructureRef is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      nodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      If no value is provided, the default value for this property of the Machine resource will be used.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              remediationStrategy:
+                description: The RemediationStrategy that controls how control plane
+                  machine remediation happens.
+                properties:
+                  maxRetry:
+                    description: "maxRetry is the Max number of retries while attempting
+                      to remediate an unhealthy machine.\nA retry happens when a machine
+                      that was created as a replacement for an unhealthy machine also
+                      fails.\nFor example, given a control plane with three machines
+                      M1, M2, M3:\n\n\tM1 become unhealthy; remediation happens, and
+                      M1-1 is created as a replacement.\n\tIf M1-1 (replacement of
+                      M1) has problems while bootstrapping it will become unhealthy,
+                      and then be\n\tremediated; such operation is considered a retry,
+                      remediation-retry #1.\n\tIf M1-2 (replacement of M1-1) becomes
+                      unhealthy, remediation-retry #2 will happen, etc.\n\nA retry
+                      could happen only after RetryPeriod from the previous retry.\nIf
+                      a machine is marked as unhealthy after MinHealthyPeriod from
+                      the previous remediation expired,\nthis is not considered a
+                      retry anymore because the new issue is assumed unrelated from
+                      the previous one.\n\nIf not set, the remedation will be retried
+                      infinitely."
+                    format: int32
+                    type: integer
+                  minHealthyPeriod:
+                    description: "minHealthyPeriod defines the duration after which
+                      KCP will consider any failure to a machine unrelated\nfrom the
+                      previous one. In this case the remediation is not considered
+                      a retry anymore, and thus the retry\ncounter restarts from 0.
+                      For example, assuming MinHealthyPeriod is set to 1h (default)\n\n\tM1
+                      become unhealthy; remediation happens, and M1-1 is created as
+                      a replacement.\n\tIf M1-1 (replacement of M1) has problems within
+                      the 1hr after the creation, also\n\tthis machine will be remediated
+                      and this operation is considered a retry - a problem related\n\tto
+                      the original issue happened to M1 -.\n\n\tIf instead the problem
+                      on M1-1 is happening after MinHealthyPeriod expired, e.g. four
+                      days after\n\tm1-1 has been created as a remediation of M1,
+                      the problem on M1-1 is considered unrelated to\n\tthe original
+                      issue happened to M1.\n\nIf not set, this value is defaulted
+                      to 1h."
+                    type: string
+                  retryPeriod:
+                    description: |-
+                      retryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                      for an unhealthy machine (a retry).
+
+                      If not set, a retry will happen immediately.
+                    type: string
+                type: object
+              replicas:
+                description: |-
+                  Number of desired machines. Defaults to 1. When stacked etcd is used only
+                  odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: |-
+                  rolloutAfter is a field to indicate a rollout should be performed
+                  after the specified time even if no changes have been made to the
+                  KubeadmControlPlane.
+                  Example: In the YAML the time can be specified in the RFC3339 format.
+                  To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                  use "2023-03-09T09:00:00Z".
+                format: date-time
+                type: string
+              rolloutBefore:
+                description: |-
+                  rolloutBefore is a field to indicate a rollout should be performed
+                  if the specified criteria is met.
+                properties:
+                  certificatesExpiryDays:
+                    description: |-
+                      certificatesExpiryDays indicates a rollout needs to be performed if the
+                      certificates of the machine will expire within the specified days.
+                    format: int32
+                    type: integer
+                type: object
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: |-
+                  The RolloutStrategy to use to replace control plane machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if
+                      RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of control planes that can be scheduled above or under the
+                          desired number of control planes.
+                          Value can be an absolute number 1 or 0.
+                          Defaults to 1.
+                          Example: when this is set to 1, the control plane can be scaled
+                          up immediately when the rolling update starts.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of rollout. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  Please note that if kubeadmConfigSpec.ClusterConfiguration.imageRepository is not set
+                  we don't allow upgrades to versions >= v1.22.0 for which kubeadm uses the old registry (k8s.gcr.io).
+                  Please use a newer patch version with the new registry instead. The default registries of kubeadm are:
+                    * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                    * k8s.gcr.io (old registry): all older versions
+                type: string
+            required:
+            - kubeadmConfigSpec
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  ErrorMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              initialized:
+                description: |-
+                  initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+                  it can accept requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              lastRemediation:
+                description: lastRemediation stores info about last remediation performed.
+                properties:
+                  machine:
+                    description: machine is the machine name of the latest machine
+                      being remediated.
+                    type: string
+                  retryCount:
+                    description: |-
+                      retryCount used to keep track of remediation retry for the last remediated machine.
+                      A retry happens when a machine that was created as a replacement for an unhealthy machine also fails.
+                    format: int32
+                    type: integer
+                  timestamp:
+                    description: timestamp is when last remediation happened. It is
+                      represented in RFC3339 form and is in UTC.
+                    format: date-time
+                    type: string
+                required:
+                - machine
+                - retryCount
+                - timestamp
+                type: object
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: |-
+                  ready denotes that the KubeadmControlPlane API Server became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane
+                  machines.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in KubeadmControlPlane's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      targeted by this KubeadmControlPlane. A machine is considered
+                      available when Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a KubeadmControlPlane's current state.
+                      Known condition types are Available, CertificatesAvailable, EtcdClusterAvailable, MachinesReady, MachinesUpToDate,
+                      ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this KubeadmControlPlane. A machine is considered ready when
+                      Machine's Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this KubeadmControlPlane. A machine is considered
+                      up-to-date when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+              version:
+                description: |-
+                  version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlaneTemplate
+    listKind: KubeadmControlPlaneTemplateList
+    plural: kubeadmcontrolplanetemplates
+    singular: kubeadmcontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneTemplateSpec defines the desired state
+              of KubeadmControlPlaneTemplate.
+            properties:
+              template:
+                description: KubeadmControlPlaneTemplateResource describes the data
+                  needed to create a KubeadmControlPlane from a template.
+                properties:
+                  spec:
+                    description: KubeadmControlPlaneSpec defines the desired state
+                      of KubeadmControlPlane.
+                    properties:
+                      kubeadmConfigSpec:
+                        description: |-
+                          kubeadmConfigSpec is a KubeadmConfigSpec
+                          to use for initializing and joining machines to the control plane.
+                        properties:
+                          clusterConfiguration:
+                            description: clusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: apiServer contains extra settings for
+                                  the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: certSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: timeoutForControlPlane controls the
+                                      timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  certificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: controllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: dns defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      imageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      imageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      external describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          certFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          keyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          dataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          extraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: |-
+                                          imageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          imageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: peerCertSANs sets extra Subject
+                                          Alternative Names for the etcd peer signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: serverCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: featureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                  `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                                  will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  kubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: dnsDomain is the dns domain used
+                                      by k8s services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      podSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      serviceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: scheduler contains extra settings for
+                                  the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: diskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: filesystems specifies the list of file
+                                  systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems
+                                    to be created.
+                                  properties:
+                                    device:
+                                      description: device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: extraOpts defined extra options
+                                        to add to the command for creating the file
+                                        system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: label specifies the file system
+                                        label to be used. If set to None, no label
+                                        is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'partition specifies the partition
+                                        to use. The valid options are: "auto|any",
+                                        "auto", "any", "none", and <NUM>, where NUM
+                                        is the actual partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: partitions specifies the list of the
+                                  partitions to setup.
+                                items:
+                                  description: Partition defines how to create and
+                                    layout a partition.
+                                  properties:
+                                    device:
+                                      description: device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        tableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: files specifies extra files to be passed
+                              to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                content:
+                                  description: content is the actual content of the
+                                    file.
+                                  type: string
+                                contentFrom:
+                                  description: contentFrom is a referenced source
+                                    of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: secret represents a secret that
+                                        should populate this file.
+                                      properties:
+                                        key:
+                                          description: key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: encoding specifies the encoding of
+                                    the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: owner specifies the ownership of the
+                                    file, e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: path specifies the full path on disk
+                                    where to store the file.
+                                  type: string
+                                permissions:
+                                  description: permissions specifies the permissions
+                                    to assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: format specifies the output format of the
+                              bootstrap data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: initConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        ttl defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: advertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      bindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: criSocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: ignorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: joinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  caCertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  controlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: localAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on
+                                      this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: advertiseAddress sets the IP
+                                          address for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          bindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: discovery specifies the options for the
+                                  kubelet to use during the TLS Bootstrap process
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      bootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: apiServerEndpoint is an IP or
+                                          domain name to the API server from which
+                                          info will be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          caCertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          unsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: |-
+                                      file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: kubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      tlsBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: criSocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: ignorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: mounts specifies a list of mount points to
+                              be setup.
+                            items:
+                              description: MountPoints defines input for generated
+                                mounts in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: ntp specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: enabled specifies whether NTP should
+                                  be enabled
+                                type: boolean
+                              servers:
+                                description: servers specifies which NTP servers to
+                                  use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: postKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: preKubeadmCommands specifies extra commands
+                              to run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+                              This will add about 40KB to userdata
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                            type: boolean
+                          users:
+                            description: users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated
+                                user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: gecos specifies the gecos to use for
+                                    the user
+                                  type: string
+                                groups:
+                                  description: groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: homeDir specifies the home directory
+                                    to use for the user
+                                  type: string
+                                inactive:
+                                  description: inactive specifies whether to mark
+                                    the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: lockPassword specifies if password
+                                    login should be disabled
+                                  type: boolean
+                                name:
+                                  description: name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: passwd specifies a hashed password
+                                    for the user
+                                  type: string
+                                primaryGroup:
+                                  description: primaryGroup specifies the primary
+                                    group for the user
+                                  type: string
+                                shell:
+                                  description: shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: sshAuthorizedKeys specifies a list
+                                    of ssh authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: sudo specifies a sudo role for the
+                                    user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineTemplate:
+                        description: |-
+                          machineTemplate contains information about how machines
+                          should be shaped when creating or updating a control plane.
+                        properties:
+                          infrastructureRef:
+                            description: |-
+                              infrastructureRef is a required reference to a custom resource
+                              offered by an infrastructure provider.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          metadata:
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects. May match selectors of replication controllers
+                                  and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels
+                                type: object
+                            type: object
+                          nodeDrainTimeout:
+                            description: |-
+                              nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                              The default value is 0, meaning that the node can be drained without any time limitations.
+                              NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            type: string
+                        required:
+                        - infrastructureRef
+                        type: object
+                      replicas:
+                        description: |-
+                          Number of desired machines. Defaults to 1. When stacked etcd is used only
+                          odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                          This is a pointer to distinguish between explicit zero and not specified.
+                        format: int32
+                        type: integer
+                      rolloutAfter:
+                        description: |-
+                          rolloutAfter is a field to indicate a rollout should be performed
+                          after the specified time even if no changes have been made to the
+                          KubeadmControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: |-
+                          The RolloutStrategy to use to replace control plane machines with
+                          new ones.
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if
+                              RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of control planes that can be scheduled above or under the
+                                  desired number of control planes.
+                                  Value can be an absolute number 1 or 0.
+                                  Defaults to 1.
+                                  Example: when this is set to 1, the control plane can be scaled
+                                  up immediately when the rolling update starts.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: |-
+                              type of rollout. Currently the only supported strategy is
+                              "RollingUpdate".
+                              Default is RollingUpdate.
+                            type: string
+                        type: object
+                      version:
+                        description: version defines the desired Kubernetes version.
+                        type: string
+                    required:
+                    - kubeadmConfigSpec
+                    - machineTemplate
+                    - version
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneTemplateSpec defines the desired state
+              of KubeadmControlPlaneTemplate.
+            properties:
+              template:
+                description: KubeadmControlPlaneTemplateResource describes the data
+                  needed to create a KubeadmControlPlane from a template.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      KubeadmControlPlaneTemplateResourceSpec defines the desired state of KubeadmControlPlane.
+                      NOTE: KubeadmControlPlaneTemplateResourceSpec is similar to KubeadmControlPlaneSpec but
+                      omits Replicas and Version fields. These fields do not make sense on the KubeadmControlPlaneTemplate,
+                      because they are calculated by the Cluster topology reconciler during reconciliation and thus cannot
+                      be configured on the KubeadmControlPlaneTemplate.
+                    properties:
+                      kubeadmConfigSpec:
+                        description: |-
+                          kubeadmConfigSpec is a KubeadmConfigSpec
+                          to use for initializing and joining machines to the control plane.
+                        properties:
+                          clusterConfiguration:
+                            description: clusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: apiServer contains extra settings for
+                                  the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: certSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: timeoutForControlPlane controls the
+                                      timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  certificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: controllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: dns defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      imageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      imageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      external describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          certFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          keyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          dataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          extraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      extraEnvs:
+                                        description: |-
+                                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment
+                                                variable. Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: |-
+                                                Variable references $(VAR_NAME) are expanded
+                                                using the previously defined environment variables in the container and
+                                                any service environment variables. If a variable cannot be resolved,
+                                                the reference in the input string will be unchanged. Double $$ are reduced
+                                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                Escaped references will never be expanded, regardless of whether the variable
+                                                exists or not.
+                                                Defaults to "".
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a
+                                                    ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: |-
+                                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a
+                                                    secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      imageRepository:
+                                        description: |-
+                                          imageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          imageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: peerCertSANs sets extra Subject
+                                          Alternative Names for the etcd peer signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: serverCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: featureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  * If not set, the default registry of kubeadm will be used, i.e.
+                                    * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                    * k8s.gcr.io (old registry): all older versions
+                                    Please note that when imageRepository is not set we don't allow upgrades to
+                                    versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                    a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                    >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                                  * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                   `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                    and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  kubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: dnsDomain is the dns domain used
+                                      by k8s services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      podSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      serviceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: scheduler contains extra settings for
+                                  the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: diskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: filesystems specifies the list of file
+                                  systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems
+                                    to be created.
+                                  properties:
+                                    device:
+                                      description: device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: extraOpts defined extra options
+                                        to add to the command for creating the file
+                                        system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: label specifies the file system
+                                        label to be used. If set to None, no label
+                                        is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'partition specifies the partition
+                                        to use. The valid options are: "auto|any",
+                                        "auto", "any", "none", and <NUM>, where NUM
+                                        is the actual partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: partitions specifies the list of the
+                                  partitions to setup.
+                                items:
+                                  description: Partition defines how to create and
+                                    layout a partition.
+                                  properties:
+                                    device:
+                                      description: device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        tableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: files specifies extra files to be passed
+                              to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                append:
+                                  description: append specifies whether to append
+                                    Content to existing file if Path exists.
+                                  type: boolean
+                                content:
+                                  description: content is the actual content of the
+                                    file.
+                                  type: string
+                                contentFrom:
+                                  description: contentFrom is a referenced source
+                                    of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: secret represents a secret that
+                                        should populate this file.
+                                      properties:
+                                        key:
+                                          description: key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: encoding specifies the encoding of
+                                    the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: owner specifies the ownership of the
+                                    file, e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: path specifies the full path on disk
+                                    where to store the file.
+                                  type: string
+                                permissions:
+                                  description: permissions specifies the permissions
+                                    to assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: format specifies the output format of the
+                              bootstrap data
+                            enum:
+                            - cloud-config
+                            - ignition
+                            type: string
+                          ignition:
+                            description: ignition contains Ignition specific configuration.
+                            properties:
+                              containerLinuxConfig:
+                                description: containerLinuxConfig contains CLC specific
+                                  configuration.
+                                properties:
+                                  additionalConfig:
+                                    description: |-
+                                      additionalConfig contains additional configuration to be merged with the Ignition
+                                      configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                                      The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                    type: string
+                                  strict:
+                                    description: strict controls if AdditionalConfig
+                                      should be strictly parsed. If so, warnings are
+                                      treated as errors.
+                                    type: boolean
+                                type: object
+                            type: object
+                          initConfiguration:
+                            description: initConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        ttl defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: advertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      bindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: criSocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: ignorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      imagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  imagePullSerial:
+                                    description: |-
+                                      imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                      Default: true (defaulted in kubeadm)
+                                    type: boolean
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  skipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          joinConfiguration:
+                            description: joinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  caCertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  controlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: localAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on
+                                      this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: advertiseAddress sets the IP
+                                          address for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          bindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: discovery specifies the options for the
+                                  kubelet to use during the TLS Bootstrap process
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      bootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: apiServerEndpoint is an IP or
+                                          domain name to the API server from which
+                                          info will be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          caCertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          unsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: |-
+                                      file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfig:
+                                        description: |-
+                                          kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                          The file is generated at the path specified in KubeConfigPath.
+
+                                          Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                          Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                        properties:
+                                          cluster:
+                                            description: |-
+                                              cluster contains information about how to communicate with the kubernetes cluster.
+
+                                              By default the following fields are automatically populated:
+                                              - Server with the Cluster's ControlPlaneEndpoint.
+                                              - CertificateAuthorityData with the Cluster's CA certificate.
+                                            properties:
+                                              certificateAuthorityData:
+                                                description: |-
+                                                  certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                                  Defaults to the Cluster's CA certificate if empty.
+                                                format: byte
+                                                type: string
+                                              insecureSkipTLSVerify:
+                                                description: insecureSkipTLSVerify
+                                                  skips the validity check for the
+                                                  server's certificate. This will
+                                                  make your HTTPS connections insecure.
+                                                type: boolean
+                                              proxyURL:
+                                                description: |-
+                                                  proxyURL is the URL to the proxy to be used for all requests made by this
+                                                  client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                                  this configuration is not provided or the empty string, the client
+                                                  attempts to construct a proxy configuration from http_proxy and
+                                                  https_proxy environment variables. If these environment variables are not
+                                                  set, the client does not attempt to proxy requests.
+
+                                                  socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                                  attach, port forward).
+                                                type: string
+                                              server:
+                                                description: |-
+                                                  server is the address of the kubernetes cluster (https://hostname:port).
+
+                                                  Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                                type: string
+                                              tlsServerName:
+                                                description: tlsServerName is used
+                                                  to check server certificate. If
+                                                  TLSServerName is empty, the hostname
+                                                  used to contact the server is used.
+                                                type: string
+                                            type: object
+                                          user:
+                                            description: |-
+                                              user contains information that describes identity information.
+                                              This is used to tell the kubernetes cluster who you are.
+                                            properties:
+                                              authProvider:
+                                                description: authProvider specifies
+                                                  a custom authentication plugin for
+                                                  the kubernetes cluster.
+                                                properties:
+                                                  config:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: config holds the
+                                                      parameters for the authentication
+                                                      plugin.
+                                                    type: object
+                                                  name:
+                                                    description: name is the name
+                                                      of the authentication plugin.
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              exec:
+                                                description: exec specifies a custom
+                                                  exec-based authentication plugin
+                                                  for the kubernetes cluster.
+                                                properties:
+                                                  apiVersion:
+                                                    description: |-
+                                                      Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                      the same encoding version as the input.
+                                                      Defaults to client.authentication.k8s.io/v1 if not set.
+                                                    type: string
+                                                  args:
+                                                    description: Arguments to pass
+                                                      to the command when executing
+                                                      it.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  command:
+                                                    description: command to execute.
+                                                    type: string
+                                                  env:
+                                                    description: |-
+                                                      env defines additional environment variables to expose to the process. These
+                                                      are unioned with the host's environment, as well as variables client-go uses
+                                                      to pass argument to the plugin.
+                                                    items:
+                                                      description: |-
+                                                        KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                        credential plugin.
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  provideClusterInfo:
+                                                    description: |-
+                                                      provideClusterInfo determines whether or not to provide cluster information,
+                                                      which could potentially contain very large CA data, to this exec plugin as a
+                                                      part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                      to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                      reading this environment variable.
+                                                    type: boolean
+                                                required:
+                                                - command
+                                                type: object
+                                            type: object
+                                        required:
+                                        - user
+                                        type: object
+                                      kubeConfigPath:
+                                        description: kubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      tlsBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: criSocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: ignorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      imagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  imagePullSerial:
+                                    description: |-
+                                      imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                      Default: true (defaulted in kubeadm)
+                                    type: boolean
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  skipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          mounts:
+                            description: mounts specifies a list of mount points to
+                              be setup.
+                            items:
+                              description: MountPoints defines input for generated
+                                mounts in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: ntp specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: enabled specifies whether NTP should
+                                  be enabled
+                                type: boolean
+                              servers:
+                                description: servers specifies which NTP servers to
+                                  use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: postKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: preKubeadmCommands specifies extra commands
+                              to run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+                              This will add about 40KB to userdata
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                              Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                              When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                            type: boolean
+                          users:
+                            description: users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated
+                                user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: gecos specifies the gecos to use for
+                                    the user
+                                  type: string
+                                groups:
+                                  description: groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: homeDir specifies the home directory
+                                    to use for the user
+                                  type: string
+                                inactive:
+                                  description: inactive specifies whether to mark
+                                    the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: lockPassword specifies if password
+                                    login should be disabled
+                                  type: boolean
+                                name:
+                                  description: name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: passwd specifies a hashed password
+                                    for the user
+                                  type: string
+                                passwdFrom:
+                                  description: passwdFrom is a referenced source of
+                                    passwd to populate the passwd.
+                                  properties:
+                                    secret:
+                                      description: secret represents a secret that
+                                        should populate this password.
+                                      properties:
+                                        key:
+                                          description: key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                primaryGroup:
+                                  description: primaryGroup specifies the primary
+                                    group for the user
+                                  type: string
+                                shell:
+                                  description: shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: sshAuthorizedKeys specifies a list
+                                    of ssh authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: sudo specifies a sudo role for the
+                                    user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineNamingStrategy:
+                        description: |-
+                          MachineNamingStrategy allows changing the naming pattern used when creating Machines.
+                          InfraMachines & KubeadmConfigs will use the same name as the corresponding Machines.
+                        properties:
+                          template:
+                            description: |-
+                              Template defines the template to use for generating the names of the Machine objects.
+                              If not defined, it will fallback to `{{ .kubeadmControlPlane.name }}-{{ .random }}`.
+                              If the generated name string exceeds 63 characters, it will be trimmed to 58 characters and will
+                              get concatenated with a random suffix of length 5.
+                              Length of the template string must not exceed 256 characters.
+                              The template allows the following variables `.cluster.name`, `.kubeadmControlPlane.name` and `.random`.
+                              The variable `.cluster.name` retrieves the name of the cluster object that owns the Machines being created.
+                              The variable `.kubeadmControlPlane.name` retrieves the name of the KubeadmControlPlane object that owns the Machines being created.
+                              The variable `.random` is substituted with random alphanumeric string, without vowels, of length 5.
+                            maxLength: 256
+                            type: string
+                        type: object
+                      machineTemplate:
+                        description: |-
+                          machineTemplate contains information about how machines
+                          should be shaped when creating or updating a control plane.
+                        properties:
+                          metadata:
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects. May match selectors of replication controllers
+                                  and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels
+                                type: object
+                            type: object
+                          nodeDeletionTimeout:
+                            description: |-
+                              nodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                              hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                              If no value is provided, the default value for this property of the Machine resource will be used.
+                            type: string
+                          nodeDrainTimeout:
+                            description: |-
+                              nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                              The default value is 0, meaning that the node can be drained without any time limitations.
+                              NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            type: string
+                          nodeVolumeDetachTimeout:
+                            description: |-
+                              nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                              to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            type: string
+                        type: object
+                      remediationStrategy:
+                        description: The RemediationStrategy that controls how control
+                          plane machine remediation happens.
+                        properties:
+                          maxRetry:
+                            description: "maxRetry is the Max number of retries while
+                              attempting to remediate an unhealthy machine.\nA retry
+                              happens when a machine that was created as a replacement
+                              for an unhealthy machine also fails.\nFor example, given
+                              a control plane with three machines M1, M2, M3:\n\n\tM1
+                              become unhealthy; remediation happens, and M1-1 is created
+                              as a replacement.\n\tIf M1-1 (replacement of M1) has
+                              problems while bootstrapping it will become unhealthy,
+                              and then be\n\tremediated; such operation is considered
+                              a retry, remediation-retry #1.\n\tIf M1-2 (replacement
+                              of M1-1) becomes unhealthy, remediation-retry #2 will
+                              happen, etc.\n\nA retry could happen only after RetryPeriod
+                              from the previous retry.\nIf a machine is marked as
+                              unhealthy after MinHealthyPeriod from the previous remediation
+                              expired,\nthis is not considered a retry anymore because
+                              the new issue is assumed unrelated from the previous
+                              one.\n\nIf not set, the remedation will be retried infinitely."
+                            format: int32
+                            type: integer
+                          minHealthyPeriod:
+                            description: "minHealthyPeriod defines the duration after
+                              which KCP will consider any failure to a machine unrelated\nfrom
+                              the previous one. In this case the remediation is not
+                              considered a retry anymore, and thus the retry\ncounter
+                              restarts from 0. For example, assuming MinHealthyPeriod
+                              is set to 1h (default)\n\n\tM1 become unhealthy; remediation
+                              happens, and M1-1 is created as a replacement.\n\tIf
+                              M1-1 (replacement of M1) has problems within the 1hr
+                              after the creation, also\n\tthis machine will be remediated
+                              and this operation is considered a retry - a problem
+                              related\n\tto the original issue happened to M1 -.\n\n\tIf
+                              instead the problem on M1-1 is happening after MinHealthyPeriod
+                              expired, e.g. four days after\n\tm1-1 has been created
+                              as a remediation of M1, the problem on M1-1 is considered
+                              unrelated to\n\tthe original issue happened to M1.\n\nIf
+                              not set, this value is defaulted to 1h."
+                            type: string
+                          retryPeriod:
+                            description: |-
+                              retryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                              for an unhealthy machine (a retry).
+
+                              If not set, a retry will happen immediately.
+                            type: string
+                        type: object
+                      rolloutAfter:
+                        description: |-
+                          rolloutAfter is a field to indicate a rollout should be performed
+                          after the specified time even if no changes have been made to the
+                          KubeadmControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutBefore:
+                        description: |-
+                          rolloutBefore is a field to indicate a rollout should be performed
+                          if the specified criteria is met.
+                        properties:
+                          certificatesExpiryDays:
+                            description: |-
+                              certificatesExpiryDays indicates a rollout needs to be performed if the
+                              certificates of the machine will expire within the specified days.
+                            format: int32
+                            type: integer
+                        type: object
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: |-
+                          The RolloutStrategy to use to replace control plane machines with
+                          new ones.
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if
+                              RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of control planes that can be scheduled above or under the
+                                  desired number of control planes.
+                                  Value can be an absolute number 1 or 0.
+                                  Defaults to 1.
+                                  Example: when this is set to 1, the control plane can be scaled
+                                  up immediately when the rolling update starts.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: |-
+                              type of rollout. Currently the only supported strategy is
+                              "RollingUpdate".
+                              Default is RollingUpdate.
+                            type: string
+                        type: object
+                    required:
+                    - kubeadmConfigSpec
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-leader-election-role
+  namespace: capi-kubeadm-control-plane-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+  name: capi-kubeadm-control-plane-manager-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machinepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-leader-election-rolebinding
+  namespace: capi-kubeadm-control-plane-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-kubeadm-control-plane-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kubeadm-control-plane-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-webhook-service
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    control-plane: controller-manager
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: control-plane-kubeadm
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+        - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+        - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.6
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: capi-kubeadm-control-plane-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-kubeadm-control-plane-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-serving-cert
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  dnsNames:
+  - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc
+  - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-kubeadm-control-plane-selfsigned-issuer
+  secretName: capi-kubeadm-control-plane-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-selfsigned-issuer
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+  failurePolicy: Fail
+  name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation-scale.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes/scale
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+  failurePolicy: Fail
+  name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None

--- a/roles/cluster_api/files/providers/control-plane-kubeadm/v1.9.6/metadata.yaml
+++ b/roles/cluster_api/files/providers/control-plane-kubeadm/v1.9.6/metadata.yaml
@@ -1,0 +1,38 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 9
+    contract: v1beta1
+  - major: 1
+    minor: 8
+    contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1
+  - major: 1
+    minor: 6
+    contract: v1beta1
+  - major: 1
+    minor: 5
+    contract: v1beta1
+  - major: 1
+    minor: 4
+    contract: v1beta1
+  - major: 1
+    minor: 3
+    contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
+    minor: 0
+    contract: v1beta1

--- a/roles/cluster_api/files/providers/infrastructure-openstack/v0.12.2/infrastructure-components.yaml
+++ b/roles/cluster_api/files/providers/infrastructure-openstack/v0.12.2/infrastructure-components.yaml
@@ -1,0 +1,11601 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+  name: capo-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    cluster.x-k8s.io/v1beta1: v1alpha7_v1beta1
+  name: openstackclusters.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capo-webhook-service
+          namespace: capo-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OpenStackCluster
+    listKind: OpenStackClusterList
+    plural: openstackclusters
+    shortNames:
+    - osc
+    singular: openstackcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this OpenStackCluster belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Cluster infrastructure is ready for OpenStack instances
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Network the cluster is using
+      jsonPath: .status.network.id
+      name: Network
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion address for breakglass access
+      jsonPath: .status.bastion.floatingIP
+      name: Bastion IP
+      type: string
+    - description: Time duration since creation of OpenStackCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha7 version of OpenStackCluster has been deprecated
+      and will be removed in a future release.
+    name: v1alpha7
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OpenStackCluster is the Schema for the openstackclusters API.
+
+          Deprecated: v1alpha7.OpenStackCluster has been replaced by v1beta1.OpenStackCluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackClusterSpec defines the desired state of OpenStackCluster.
+            properties:
+              allowAllInClusterTraffic:
+                description: |-
+                  AllowAllInClusterTraffic is only used when managed security groups are in use.
+                  If set to true, the rules for the managed security groups are configured so that all
+                  ingress and egress between cluster nodes is permitted, allowing CNIs other than
+                  Calico to be used.
+                type: boolean
+              apiServerFixedIP:
+                description: |-
+                  APIServerFixedIP is the fixed IP which will be associated with the API server.
+                  In the case where the API server has a floating IP but not a managed load balancer,
+                  this field is not used.
+                  If a managed load balancer is used and this field is not specified, a fixed IP will
+                  be dynamically allocated for the load balancer.
+                  If a managed load balancer is not used AND the API server floating IP is disabled,
+                  this field MUST be specified and should correspond to a pre-allocated port that
+                  holds the fixed IP to be used as a VIP.
+                type: string
+              apiServerFloatingIP:
+                description: |-
+                  APIServerFloatingIP is the floatingIP which will be associated with the API server.
+                  The floatingIP will be created if it does not already exist.
+                  If not specified, a new floatingIP is allocated.
+                  This field is not used if DisableAPIServerFloatingIP is set to true.
+                type: string
+              apiServerLoadBalancer:
+                description: |-
+                  APIServerLoadBalancer configures the optional LoadBalancer for the APIServer.
+                  It must be activated by setting `enabled: true`.
+                properties:
+                  additionalPorts:
+                    description: AdditionalPorts adds additional tcp ports to the
+                      load balancer.
+                    items:
+                      type: integer
+                    type: array
+                  allowedCidrs:
+                    description: AllowedCIDRs restrict access to all API-Server listeners
+                      to the given address CIDRs.
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled defines whether a load balancer should be
+                      created.
+                    type: boolean
+                  provider:
+                    description: Octavia Provider Used to create load balancer
+                    type: string
+                type: object
+              apiServerPort:
+                description: |-
+                  APIServerPort is the port on which the listener on the APIServer
+                  will be created
+                type: integer
+              bastion:
+                description: |-
+                  Bastion is the OpenStack instance to login the nodes
+
+                  As a rolling update is not ideal during a bastion host session, we
+                  prevent changes to a running bastion configuration. Set `enabled: false` to
+                  make changes.
+                properties:
+                  availabilityZone:
+                    type: string
+                  enabled:
+                    type: boolean
+                  instance:
+                    description: Instance for the bastion itself
+                    properties:
+                      additionalBlockDevices:
+                        description: AdditionalBlockDevices is a list of specifications
+                          for additional block devices to attach to the server instance
+                        items:
+                          description: AdditionalBlockDevice is a block device to
+                            attach to the server.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the block device in the context of a machine.
+                                If the block device is a volume, the Cinder volume will be named
+                                as a combination of the machine name and this name.
+                                Also, this name will be used for tagging the block device.
+                                Information about the block device tag can be obtained from the OpenStack
+                                metadata API or the config drive.
+                              type: string
+                            sizeGiB:
+                              description: SizeGiB is the size of the block device
+                                in gibibytes (GiB).
+                              type: integer
+                            storage:
+                              description: |-
+                                Storage specifies the storage type of the block device and
+                                additional storage options.
+                              properties:
+                                type:
+                                  description: |-
+                                    Type is the type of block device to create.
+                                    This can be either "Volume" or "Local".
+                                  type: string
+                                volume:
+                                  description: Volume contains additional storage
+                                    options for a volume block device.
+                                  properties:
+                                    availabilityZone:
+                                      description: |-
+                                        AvailabilityZone is the volume availability zone to create the volume in.
+                                        If omitted, the availability zone of the server will be used.
+                                        The availability zone must NOT contain spaces otherwise it will lead to volume that belongs
+                                        to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for
+                                        further information.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        Type is the Cinder volume type of the volume.
+                                        If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                        will be used.
+                                      type: string
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - sizeGiB
+                          - storage
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      cloudName:
+                        description: The name of the cloud to use from the clouds
+                          secret
+                        type: string
+                      configDrive:
+                        description: Config Drive support
+                        type: boolean
+                      flavor:
+                        description: The flavor reference for the flavor for your
+                          server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
+                        type: string
+                      floatingIP:
+                        description: |-
+                          The floatingIP which will be associated to the machine, only used for master.
+                          The floatingIP should have been created and haven't been associated.
+                        type: string
+                      identityRef:
+                        description: |-
+                          IdentityRef is a reference to a identity to be used when reconciling this cluster.
+                          If not specified, the identity ref of the cluster will be used instead.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind of the identity. Must be supported by the infrastructure
+                              provider and may be either cluster or namespace-scoped.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name of the infrastructure identity to be used.
+                              Must be either a cluster-scoped resource, or namespaced-scoped
+                              resource the same namespace as the resource(s) being provisioned.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      image:
+                        description: |-
+                          The name of the image to use for your server instance.
+                          If the RootVolume is specified, this will be ignored and use rootVolume directly.
+                        type: string
+                      imageUUID:
+                        description: |-
+                          The uuid of the image to use for your server instance.
+                          if it's empty, Image name will be used
+                        type: string
+                      instanceID:
+                        description: InstanceID is the OpenStack instance ID for this
+                          machine.
+                        type: string
+                      ports:
+                        description: |-
+                          Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                          If not specified a default port will be added for the default cluster network.
+                        items:
+                          properties:
+                            adminStateUp:
+                              type: boolean
+                            allowedAddressPairs:
+                              items:
+                                properties:
+                                  ipAddress:
+                                    type: string
+                                  macAddress:
+                                    type: string
+                                type: object
+                              type: array
+                            description:
+                              type: string
+                            disablePortSecurity:
+                              description: |-
+                                DisablePortSecurity enables or disables the port security when set.
+                                When not set, it takes the value of the corresponding field at the network level.
+                              type: boolean
+                            fixedIPs:
+                              description: Specify pairs of subnet and/or IP address.
+                                These should be subnets of the network with the given
+                                NetworkID.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    type: string
+                                  subnet:
+                                    description: |-
+                                      Subnet is an openstack subnet query that will return the id of a subnet to create
+                                      the fixed IP of a port in. This query must not return more than one subnet.
+                                    properties:
+                                      cidr:
+                                        type: string
+                                      description:
+                                        type: string
+                                      gateway_ip:
+                                        type: string
+                                      id:
+                                        type: string
+                                      ipVersion:
+                                        type: integer
+                                      ipv6AddressMode:
+                                        type: string
+                                      ipv6RaMode:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        type: string
+                                      notTagsAny:
+                                        type: string
+                                      projectId:
+                                        type: string
+                                      tags:
+                                        type: string
+                                      tagsAny:
+                                        type: string
+                                    type: object
+                                required:
+                                - subnet
+                                type: object
+                              type: array
+                            hostId:
+                              description: The ID of the host where the port is allocated
+                              type: string
+                            macAddress:
+                              type: string
+                            nameSuffix:
+                              description: Used to make the name of the port unique.
+                                If unspecified, instead the 0-based index of the port
+                                in the list is used.
+                              type: string
+                            network:
+                              description: |-
+                                Network is a query for an openstack network that the port will be created or discovered on.
+                                This will fail if the query returns more than one network.
+                              properties:
+                                description:
+                                  type: string
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  type: string
+                                notTagsAny:
+                                  type: string
+                                projectId:
+                                  type: string
+                                tags:
+                                  type: string
+                                tagsAny:
+                                  type: string
+                              type: object
+                            profile:
+                              description: |-
+                                Profile is a set of key-value pairs that are used for binding details.
+                                We intentionally don't expose this as a map[string]string because we only want to enable
+                                the users to set the values of the keys that are known to work in OpenStack Networking API.
+                                See https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                              properties:
+                                ovsHWOffload:
+                                  description: OVSHWOffload enables or disables the
+                                    OVS hardware offload feature.
+                                  type: boolean
+                                trustedVF:
+                                  description: TrustedVF enables or disables the “trusted
+                                    mode” for the VF.
+                                  type: boolean
+                              type: object
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
+                            securityGroupFilters:
+                              description: The names, uuids, filters or any combination
+                                these of the security groups to assign to the instance
+                              items:
+                                properties:
+                                  description:
+                                    type: string
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  notTags:
+                                    type: string
+                                  notTagsAny:
+                                    type: string
+                                  projectId:
+                                    type: string
+                                  tags:
+                                    type: string
+                                  tagsAny:
+                                    type: string
+                                type: object
+                              type: array
+                            tags:
+                              description: |-
+                                Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                                These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            trunk:
+                              description: Enables and disables trunk at port level.
+                                If not provided, openStackMachine.Spec.Trunk is inherited.
+                              type: boolean
+                            valueSpecs:
+                              description: |-
+                                Value specs are extra parameters to include in the API request with OpenStack.
+                                This is an extension point for the API, so what they do and if they are supported,
+                                depends on the specific OpenStack implementation.
+                              items:
+                                description: ValueSpec represents a single value_spec
+                                  key-value pair.
+                                properties:
+                                  key:
+                                    description: Key is the key in the key-value pair.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the key-value pair.
+                                      This is just for identifying the pair and will not be sent to the OpenStack API.
+                                    type: string
+                                  value:
+                                    description: Value is the value in the key-value
+                                      pair.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            vnicType:
+                              description: The virtual network interface card (vNIC)
+                                type that is bound to the neutron port.
+                              type: string
+                          type: object
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      rootVolume:
+                        description: The volume metadata to boot from
+                        properties:
+                          availabilityZone:
+                            type: string
+                          diskSize:
+                            type: integer
+                          volumeType:
+                            type: string
+                        type: object
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the instance
+                        items:
+                          properties:
+                            description:
+                              type: string
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              type: string
+                            notTagsAny:
+                              type: string
+                            projectId:
+                              type: string
+                            tags:
+                              type: string
+                            tagsAny:
+                              type: string
+                          type: object
+                        type: array
+                      serverGroupID:
+                        description: The server group to assign the machine to
+                        type: string
+                      serverMetadata:
+                        additionalProperties:
+                          type: string
+                        description: Metadata mapping. Allows you to create a map
+                          of key value pairs to add to the server instance.
+                        type: object
+                      sshKeyName:
+                        description: The ssh key to inject in the instance
+                        type: string
+                      tags:
+                        description: |-
+                          Machine tags
+                          Requires Nova api 2.52 minimum!
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      trunk:
+                        description: Whether the server instance is created on a trunk
+                          port or not.
+                        type: boolean
+                    type: object
+                type: object
+              cloudName:
+                description: The name of the cloud to use from the clouds secret
+                type: string
+              controlPlaneAvailabilityZones:
+                description: ControlPlaneAvailabilityZones is the az to deploy control
+                  plane to
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneOmitAvailabilityZone:
+                description: |-
+                  Indicates whether to omit the az for control plane nodes, allowing the Nova scheduler
+                  to make a decision on which az to use based on other scheduling constraints
+                type: boolean
+              disableAPIServerFloatingIP:
+                description: |-
+                  DisableAPIServerFloatingIP determines whether or not to attempt to attach a floating
+                  IP to the API server. This allows for the creation of clusters when attaching a floating
+                  IP to the API server (and hence, in many cases, exposing the API server to the internet)
+                  is not possible or desirable, e.g. if using a shared VLAN for communication between
+                  management and workload clusters or when the management cluster is inside the
+                  project network.
+                  This option requires that the API server use a VIP on the cluster network so that the
+                  underlying machines can change without changing ControlPlaneEndpoint.Host.
+                  When using a managed load balancer, this VIP will be managed automatically.
+                  If not using a managed load balancer, cluster configuration will fail without additional
+                  configuration to manage the VIP on the control plane machines, which falls outside of
+                  the scope of this controller.
+                type: boolean
+              disablePortSecurity:
+                description: |-
+                  DisablePortSecurity disables the port security of the network created for the
+                  Kubernetes cluster, which also disables SecurityGroups
+                type: boolean
+              dnsNameservers:
+                description: |-
+                  DNSNameservers is the list of nameservers for OpenStack Subnet being created.
+                  Set this value when you need create a new network/subnet while the access
+                  through DNS is required.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              externalNetworkId:
+                description: |-
+                  ExternalNetworkID is the ID of an external OpenStack Network. This is necessary
+                  to get public internet to the VMs.
+                type: string
+              externalRouterIPs:
+                description: |-
+                  ExternalRouterIPs is an array of externalIPs on the respective subnets.
+                  This is necessary if the router needs a fixed ip in a specific subnet.
+                items:
+                  properties:
+                    fixedIP:
+                      description: The FixedIP in the corresponding subnet
+                      type: string
+                    subnet:
+                      description: The subnet in which the FixedIP is used for the
+                        Gateway of this router
+                      properties:
+                        cidr:
+                          type: string
+                        description:
+                          type: string
+                        gateway_ip:
+                          type: string
+                        id:
+                          type: string
+                        ipVersion:
+                          type: integer
+                        ipv6AddressMode:
+                          type: string
+                        ipv6RaMode:
+                          type: string
+                        name:
+                          type: string
+                        notTags:
+                          type: string
+                        notTagsAny:
+                          type: string
+                        projectId:
+                          type: string
+                        tags:
+                          type: string
+                        tagsAny:
+                          type: string
+                      type: object
+                  required:
+                  - subnet
+                  type: object
+                type: array
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when
+                  reconciling this cluster
+                properties:
+                  kind:
+                    description: |-
+                      Kind of the identity. Must be supported by the infrastructure
+                      provider and may be either cluster or namespace-scoped.
+                    minLength: 1
+                    type: string
+                  name:
+                    description: |-
+                      Name of the infrastructure identity to be used.
+                      Must be either a cluster-scoped resource, or namespaced-scoped
+                      resource the same namespace as the resource(s) being provisioned.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              managedSecurityGroups:
+                description: |-
+                  ManagedSecurityGroups determines whether OpenStack security groups for the cluster
+                  will be managed by the OpenStack provider or whether pre-existing security groups will
+                  be specified as part of the configuration.
+                  By default, the managed security groups have rules that allow the Kubelet, etcd, the
+                  Kubernetes API server and the Calico CNI plugin to function correctly.
+                type: boolean
+              network:
+                description: If NodeCIDR cannot be set this can be used to detect
+                  an existing network.
+                properties:
+                  description:
+                    type: string
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  notTags:
+                    type: string
+                  notTagsAny:
+                    type: string
+                  projectId:
+                    type: string
+                  tags:
+                    type: string
+                  tagsAny:
+                    type: string
+                type: object
+              networkMtu:
+                description: |-
+                  NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
+                  This value will be used only if the Cluster actuator creates the network.
+                  If leaved empty, the network will have the default MTU defined in Openstack network service.
+                  To use this field, the Openstack installation requires the net-mtu neutron API extension.
+                type: integer
+              nodeCidr:
+                description: |-
+                  NodeCIDR is the OpenStack Subnet to be created. Cluster actuator will create a
+                  network, a subnet with NodeCIDR, and a router connected to this subnet.
+                  If you leave this empty, no network will be created.
+                type: string
+              router:
+                description: |-
+                  If NodeCIDR is set this option can be used to detect an existing router.
+                  If specified, no new router will be created.
+                properties:
+                  description:
+                    type: string
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  notTags:
+                    type: string
+                  notTagsAny:
+                    type: string
+                  projectId:
+                    type: string
+                  tags:
+                    type: string
+                  tagsAny:
+                    type: string
+                type: object
+              subnet:
+                description: If NodeCIDR cannot be set this can be used to detect
+                  an existing subnet.
+                properties:
+                  cidr:
+                    type: string
+                  description:
+                    type: string
+                  gateway_ip:
+                    type: string
+                  id:
+                    type: string
+                  ipVersion:
+                    type: integer
+                  ipv6AddressMode:
+                    type: string
+                  ipv6RaMode:
+                    type: string
+                  name:
+                    type: string
+                  notTags:
+                    type: string
+                  notTagsAny:
+                    type: string
+                  projectId:
+                    type: string
+                  tags:
+                    type: string
+                  tagsAny:
+                    type: string
+                type: object
+              tags:
+                description: Tags for all resources in cluster
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            type: object
+          status:
+            description: OpenStackClusterStatus defines the observed state of OpenStackCluster.
+            properties:
+              apiServerLoadBalancer:
+                description: APIServerLoadBalancer describes the api server load balancer
+                  if one exists
+                properties:
+                  allowedCIDRs:
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    type: string
+                  internalIP:
+                    type: string
+                  ip:
+                    type: string
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - internalIP
+                - ip
+                - name
+                type: object
+              bastion:
+                properties:
+                  floatingIP:
+                    type: string
+                  id:
+                    type: string
+                  ip:
+                    type: string
+                  name:
+                    type: string
+                  sshKeyName:
+                    type: string
+                  state:
+                    description: InstanceState describes the state of an OpenStack
+                      instance.
+                    type: string
+                type: object
+              bastionSecurityGroup:
+                description: |-
+                  SecurityGroup represents the basic information of the associated
+                  OpenStack Neutron Security Group.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: |-
+                        SecurityGroupRule represent the basic information of the associated OpenStack
+                        Security Group Role.
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        etherType:
+                          type: string
+                        name:
+                          type: string
+                        portRangeMax:
+                          type: integer
+                        portRangeMin:
+                          type: integer
+                        protocol:
+                          type: string
+                        remoteGroupID:
+                          type: string
+                        remoteIPPrefix:
+                          type: string
+                        securityGroupID:
+                          type: string
+                      required:
+                      - description
+                      - direction
+                      - etherType
+                      - name
+                      - portRangeMax
+                      - portRangeMin
+                      - protocol
+                      - remoteGroupID
+                      - remoteIPPrefix
+                      - securityGroupID
+                      type: object
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              controlPlaneSecurityGroup:
+                description: |-
+                  ControlPlaneSecurityGroups contains all the information about the OpenStack
+                  Security Group that needs to be applied to control plane nodes.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: |-
+                        SecurityGroupRule represent the basic information of the associated OpenStack
+                        Security Group Role.
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        etherType:
+                          type: string
+                        name:
+                          type: string
+                        portRangeMax:
+                          type: integer
+                        portRangeMin:
+                          type: integer
+                        protocol:
+                          type: string
+                        remoteGroupID:
+                          type: string
+                        remoteIPPrefix:
+                          type: string
+                        securityGroupID:
+                          type: string
+                      required:
+                      - description
+                      - direction
+                      - etherType
+                      - name
+                      - portRangeMax
+                      - portRangeMin
+                      - protocol
+                      - remoteGroupID
+                      - remoteIPPrefix
+                      - securityGroupID
+                      type: object
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              externalNetwork:
+                description: externalNetwork contains information about the external
+                  network used for default ingress and egress traffic.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains represent OpenStack availability zones
+                type: object
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the OpenStackCluster and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the OpenStackCluster's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of
+                  OpenStackClusters can be added as events to the OpenStackCluster object
+                  and/or logged in the controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the OpenStackCluster and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the OpenStackCluster's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of
+                  OpenStackClusters can be added as events to the OpenStackCluster object
+                  and/or logged in the controller's output.
+                type: string
+              network:
+                description: Network contains information about the created OpenStack
+                  Network.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  subnets:
+                    description: Subnets is a list of subnets associated with the
+                      default cluster network. Machines which use the default cluster
+                      network will get an address from all of these subnets.
+                    items:
+                      description: Subnet represents basic information about the associated
+                        OpenStack Neutron Subnet.
+                      properties:
+                        cidr:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        tags:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                      - id
+                      - name
+                      type: object
+                    type: array
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              ready:
+                type: boolean
+              router:
+                description: Router describes the default cluster router
+                properties:
+                  id:
+                    type: string
+                  ips:
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              workerSecurityGroup:
+                description: |-
+                  WorkerSecurityGroup contains all the information about the OpenStack Security
+                  Group that needs to be applied to worker nodes.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: |-
+                        SecurityGroupRule represent the basic information of the associated OpenStack
+                        Security Group Role.
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        etherType:
+                          type: string
+                        name:
+                          type: string
+                        portRangeMax:
+                          type: integer
+                        portRangeMin:
+                          type: integer
+                        protocol:
+                          type: string
+                        remoteGroupID:
+                          type: string
+                        remoteIPPrefix:
+                          type: string
+                        securityGroupID:
+                          type: string
+                      required:
+                      - description
+                      - direction
+                      - etherType
+                      - name
+                      - portRangeMax
+                      - portRangeMin
+                      - protocol
+                      - remoteGroupID
+                      - remoteIPPrefix
+                      - securityGroupID
+                      type: object
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+            required:
+            - ready
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this OpenStackCluster belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Cluster infrastructure is ready for OpenStack instances
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Network the cluster is using
+      jsonPath: .status.network.id
+      name: Network
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion address for breakglass access
+      jsonPath: .status.bastion.floatingIP
+      name: Bastion IP
+      type: string
+    - description: Time duration since creation of OpenStackCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackCluster is the Schema for the openstackclusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackClusterSpec defines the desired state of OpenStackCluster.
+            properties:
+              apiServerFixedIP:
+                description: |-
+                  APIServerFixedIP is the fixed IP which will be associated with the API server.
+                  In the case where the API server has a floating IP but not a managed load balancer,
+                  this field is not used.
+                  If a managed load balancer is used and this field is not specified, a fixed IP will
+                  be dynamically allocated for the load balancer.
+                  If a managed load balancer is not used AND the API server floating IP is disabled,
+                  this field MUST be specified and should correspond to a pre-allocated port that
+                  holds the fixed IP to be used as a VIP.
+                type: string
+              apiServerFloatingIP:
+                description: |-
+                  APIServerFloatingIP is the floatingIP which will be associated with the API server.
+                  The floatingIP will be created if it does not already exist.
+                  If not specified, a new floatingIP is allocated.
+                  This field is not used if DisableAPIServerFloatingIP is set to true.
+                type: string
+              apiServerLoadBalancer:
+                description: |-
+                  APIServerLoadBalancer configures the optional LoadBalancer for the APIServer.
+                  If not specified, no load balancer will be created for the API server.
+                properties:
+                  additionalPorts:
+                    description: AdditionalPorts adds additional tcp ports to the
+                      load balancer.
+                    items:
+                      type: integer
+                    type: array
+                    x-kubernetes-list-type: set
+                  allowedCIDRs:
+                    description: AllowedCIDRs restrict access to all API-Server listeners
+                      to the given address CIDRs.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  availabilityZone:
+                    description: AvailabilityZone is the failure domain that will
+                      be used to create the APIServerLoadBalancer Spec.
+                    type: string
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled defines whether a load balancer should be created. This value
+                      defaults to true if an APIServerLoadBalancer is given.
+
+                      There is no reason to set this to false. To disable creation of the
+                      API server loadbalancer, omit the APIServerLoadBalancer field in the
+                      cluster spec instead.
+                    type: boolean
+                  flavor:
+                    description: Flavor is the flavor name that will be used to create
+                      the APIServerLoadBalancer Spec.
+                    type: string
+                  network:
+                    description: Network defines which network should the load balancer
+                      be allocated on.
+                    maxProperties: 1
+                    minProperties: 1
+                    properties:
+                      filter:
+                        description: Filter specifies a filter to select an OpenStack
+                          network. If provided, cannot be empty.
+                        minProperties: 1
+                        properties:
+                          description:
+                            type: string
+                          name:
+                            type: string
+                          notTags:
+                            description: |-
+                              NotTags is a list of tags to filter by. If specified, resources which
+                              contain all of the given tags will be excluded from the result.
+                            items:
+                              description: |-
+                                NeutronTag represents a tag on a Neutron resource.
+                                It may not be empty and may not contain commas.
+                              minLength: 1
+                              pattern: ^[^,]+$
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notTagsAny:
+                            description: |-
+                              NotTagsAny is a list of tags to filter by. If specified, resources
+                              which contain any of the given tags will be excluded from the result.
+                            items:
+                              description: |-
+                                NeutronTag represents a tag on a Neutron resource.
+                                It may not be empty and may not contain commas.
+                              minLength: 1
+                              pattern: ^[^,]+$
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          projectID:
+                            type: string
+                          tags:
+                            description: |-
+                              Tags is a list of tags to filter by. If specified, the resource must
+                              have all of the tags specified to be included in the result.
+                            items:
+                              description: |-
+                                NeutronTag represents a tag on a Neutron resource.
+                                It may not be empty and may not contain commas.
+                              minLength: 1
+                              pattern: ^[^,]+$
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          tagsAny:
+                            description: |-
+                              TagsAny is a list of tags to filter by. If specified, the resource
+                              must have at least one of the tags specified to be included in the
+                              result.
+                            items:
+                              description: |-
+                                NeutronTag represents a tag on a Neutron resource.
+                                It may not be empty and may not contain commas.
+                              minLength: 1
+                              pattern: ^[^,]+$
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
+                      id:
+                        description: ID is the ID of the network to use. If ID is
+                          provided, the other filters cannot be provided. Must be
+                          in UUID format.
+                        format: uuid
+                        type: string
+                    type: object
+                  provider:
+                    description: |-
+                      Provider specifies name of a specific Octavia provider to use for the
+                      API load balancer. The Octavia default will be used if it is not
+                      specified.
+                    type: string
+                  subnets:
+                    description: |-
+                      Subnets define which subnets should the load balancer be allocated on.
+                      It is expected that subnets are located on the network specified in this resource.
+                      Only the first element is taken into account.
+                      kubebuilder:validation:MaxLength:=2
+                    items:
+                      description: SubnetParam specifies an OpenStack subnet to use.
+                        It may be specified by either ID or filter, but not both.
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        filter:
+                          description: Filter specifies a filter to select the subnet.
+                            It must match exactly one subnet.
+                          minProperties: 1
+                          properties:
+                            cidr:
+                              type: string
+                            description:
+                              type: string
+                            gatewayIP:
+                              type: string
+                            ipVersion:
+                              type: integer
+                            ipv6AddressMode:
+                              type: string
+                            ipv6RAMode:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              description: |-
+                                NotTags is a list of tags to filter by. If specified, resources which
+                                contain all of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            notTagsAny:
+                              description: |-
+                                NotTagsAny is a list of tags to filter by. If specified, resources
+                                which contain any of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            projectID:
+                              type: string
+                            tags:
+                              description: |-
+                                Tags is a list of tags to filter by. If specified, the resource must
+                                have all of the tags specified to be included in the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            tagsAny:
+                              description: |-
+                                TagsAny is a list of tags to filter by. If specified, the resource
+                                must have at least one of the tags specified to be included in the
+                                result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          type: object
+                        id:
+                          description: ID is the uuid of the subnet. It will not be
+                            validated.
+                          format: uuid
+                          type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - enabled
+                type: object
+              apiServerPort:
+                description: |-
+                  APIServerPort is the port on which the listener on the APIServer
+                  will be created. If specified, it must be an integer between 0 and 65535.
+                maximum: 65535
+                minimum: 0
+                type: integer
+              bastion:
+                description: |-
+                  Bastion is the OpenStack instance to login the nodes
+
+                  As a rolling update is not ideal during a bastion host session, we
+                  prevent changes to a running bastion configuration. To make changes, it's required
+                  to first set `enabled: false` which will remove the bastion and then changes can be made.
+                properties:
+                  availabilityZone:
+                    description: AvailabilityZone is the failure domain that will
+                      be used to create the Bastion Spec.
+                    type: string
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled means that bastion is enabled. The bastion is enabled by
+                      default if this field is not specified. Set this field to false to disable the
+                      bastion.
+
+                      It is not currently possible to remove the bastion from the cluster
+                      spec without first disabling it by setting this field to false and
+                      waiting until the bastion has been deleted.
+                    type: boolean
+                  floatingIP:
+                    description: |-
+                      FloatingIP which will be associated to the bastion machine. It's the IP address, not UUID.
+                      The floating IP should already exist and should not be associated with a port. If FIP of this address does not
+                      exist, CAPO will try to create it, but by default only OpenStack administrators have privileges to do so.
+                    format: ipv4
+                    type: string
+                  spec:
+                    description: Spec for the bastion itself
+                    properties:
+                      additionalBlockDevices:
+                        description: AdditionalBlockDevices is a list of specifications
+                          for additional block devices to attach to the server instance
+                        items:
+                          description: AdditionalBlockDevice is a block device to
+                            attach to the server.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the block device in the context of a machine.
+                                If the block device is a volume, the Cinder volume will be named
+                                as a combination of the machine name and this name.
+                                Also, this name will be used for tagging the block device.
+                                Information about the block device tag can be obtained from the OpenStack
+                                metadata API or the config drive.
+                                Name cannot be 'root', which is reserved for the root volume.
+                              type: string
+                            sizeGiB:
+                              description: SizeGiB is the size of the block device
+                                in gibibytes (GiB).
+                              minimum: 1
+                              type: integer
+                            storage:
+                              description: |-
+                                Storage specifies the storage type of the block device and
+                                additional storage options.
+                              properties:
+                                type:
+                                  description: |-
+                                    Type is the type of block device to create.
+                                    This can be either "Volume" or "Local".
+                                  type: string
+                                volume:
+                                  description: Volume contains additional storage
+                                    options for a volume block device.
+                                  properties:
+                                    availabilityZone:
+                                      description: |-
+                                        AvailabilityZone is the volume availability zone to create the volume
+                                        in. If not specified, the volume will be created without an explicit
+                                        availability zone.
+                                      properties:
+                                        from:
+                                          default: Name
+                                          description: |-
+                                            From specifies where we will obtain the availability zone for the
+                                            volume. The options are "Name" and "Machine". If "Name" is specified
+                                            then the Name field must also be specified. If "Machine" is specified
+                                            the volume will use the value of FailureDomain, if any, from the
+                                            associated Machine.
+                                          enum:
+                                          - Name
+                                          - Machine
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name is the name of a volume availability zone to use. It is required
+                                            if From is "Name". The volume availability zone name may not contain
+                                            spaces.
+                                          minLength: 1
+                                          pattern: ^[^ ]+$
+                                          type: string
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: name is required when from is 'Name'
+                                          or default
+                                        rule: '!has(self.from) || self.from == ''Name''
+                                          ? has(self.name) : !has(self.name)'
+                                    type:
+                                      description: |-
+                                        Type is the Cinder volume type of the volume.
+                                        If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                        will be used.
+                                      type: string
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - sizeGiB
+                          - storage
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      configDrive:
+                        description: Config Drive support
+                        type: boolean
+                      flavor:
+                        description: The flavor reference for the flavor for your
+                          server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
+                        type: string
+                      floatingIPPoolRef:
+                        description: |-
+                          floatingIPPoolRef is a reference to a IPPool that will be assigned
+                          to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
+                          will be assigned to the OpenStackMachine.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      identityRef:
+                        description: |-
+                          IdentityRef is a reference to a secret holding OpenStack credentials
+                          to be used when reconciling this machine. If not specified, the
+                          credentials specified in the cluster will be used.
+                        properties:
+                          cloudName:
+                            description: CloudName specifies the name of the entry
+                              in the clouds.yaml file to use.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of a secret in the same namespace as the resource being provisioned.
+                              The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                              The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                            type: string
+                          region:
+                            description: |-
+                              Region specifies an OpenStack region to use. If specified, it overrides
+                              any value in clouds.yaml. If specified for an OpenStackMachine, its
+                              value will be included in providerID.
+                            type: string
+                        required:
+                        - cloudName
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                            == oldSelf.region
+                      image:
+                        description: |-
+                          The image to use for your server instance.
+                          If the rootVolume is specified, this will be used when creating the root volume.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: |-
+                              Filter describes a query for an image. If specified, the combination
+                              of name and tags must return a single matching image or an error will
+                              be raised.
+                            minProperties: 1
+                            properties:
+                              name:
+                                description: The name of the desired image. If specified,
+                                  the combination of name and tags must return a single
+                                  matching image or an error will be raised.
+                                type: string
+                              tags:
+                                description: The tags associated with the desired
+                                  image. If specified, the combination of name and
+                                  tags must return a single matching image or an error
+                                  will be raised.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the uuid of the image. ID will not
+                              be validated before use.
+                            format: uuid
+                            type: string
+                          imageRef:
+                            description: |-
+                              ImageRef is a reference to an ORC Image in the same namespace as the
+                              referring object.
+                            properties:
+                              name:
+                                description: Name is the name of the referenced resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      ports:
+                        description: |-
+                          Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                          If not specified a default port will be added for the default cluster network.
+                        items:
+                          properties:
+                            adminStateUp:
+                              description: AdminStateUp specifies whether the port
+                                should be created in the up (true) or down (false)
+                                state. The default is up.
+                              type: boolean
+                            allowedAddressPairs:
+                              description: |-
+                                AllowedAddressPairs is a list of address pairs which Neutron will
+                                allow the port to send traffic from in addition to the port's
+                                addresses. If not specified, the MAC Address will be the MAC Address
+                                of the port. Depending on the configuration of Neutron, it may be
+                                supported to specify a CIDR instead of a specific IP address.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    description: |-
+                                      IPAddress is the IP address of the allowed address pair. Depending on
+                                      the configuration of Neutron, it may be supported to specify a CIDR
+                                      instead of a specific IP address.
+                                    type: string
+                                  macAddress:
+                                    description: |-
+                                      MACAddress is the MAC address of the allowed address pair. If not
+                                      specified, the MAC address will be the MAC address of the port.
+                                    type: string
+                                required:
+                                - ipAddress
+                                type: object
+                              type: array
+                            description:
+                              description: Description is a human-readable description
+                                for the port.
+                              type: string
+                            disablePortSecurity:
+                              description: |-
+                                DisablePortSecurity enables or disables the port security when set.
+                                When not set, it takes the value of the corresponding field at the network level.
+                              type: boolean
+                            fixedIPs:
+                              description: FixedIPs is a list of pairs of subnet and/or
+                                IP address to assign to the port. If specified, these
+                                must be subnets of the port's network.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    description: |-
+                                      IPAddress is a specific IP address to assign to the port. If Subnet
+                                      is also specified, IPAddress must be a valid IP address in the
+                                      subnet. If Subnet is not specified, IPAddress must be a valid IP
+                                      address in any subnet of the port's network.
+                                    type: string
+                                  subnet:
+                                    description: |-
+                                      Subnet is an openstack subnet query that will return the id of a subnet to create
+                                      the fixed IP of a port in. This query must not return more than one subnet.
+                                    maxProperties: 1
+                                    minProperties: 1
+                                    properties:
+                                      filter:
+                                        description: Filter specifies a filter to
+                                          select the subnet. It must match exactly
+                                          one subnet.
+                                        minProperties: 1
+                                        properties:
+                                          cidr:
+                                            type: string
+                                          description:
+                                            type: string
+                                          gatewayIP:
+                                            type: string
+                                          ipVersion:
+                                            type: integer
+                                          ipv6AddressMode:
+                                            type: string
+                                          ipv6RAMode:
+                                            type: string
+                                          name:
+                                            type: string
+                                          notTags:
+                                            description: |-
+                                              NotTags is a list of tags to filter by. If specified, resources which
+                                              contain all of the given tags will be excluded from the result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          notTagsAny:
+                                            description: |-
+                                              NotTagsAny is a list of tags to filter by. If specified, resources
+                                              which contain any of the given tags will be excluded from the result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          projectID:
+                                            type: string
+                                          tags:
+                                            description: |-
+                                              Tags is a list of tags to filter by. If specified, the resource must
+                                              have all of the tags specified to be included in the result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          tagsAny:
+                                            description: |-
+                                              TagsAny is a list of tags to filter by. If specified, the resource
+                                              must have at least one of the tags specified to be included in the
+                                              result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        type: object
+                                      id:
+                                        description: ID is the uuid of the subnet.
+                                          It will not be validated.
+                                        format: uuid
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            hostID:
+                              description: HostID specifies the ID of the host where
+                                the port resides.
+                              type: string
+                            macAddress:
+                              description: MACAddress specifies the MAC address of
+                                the port. If not specified, the MAC address will be
+                                generated.
+                              type: string
+                            nameSuffix:
+                              description: NameSuffix will be appended to the name
+                                of the port if specified. If unspecified, instead
+                                the 0-based index of the port in the list is used.
+                              type: string
+                            network:
+                              description: |-
+                                Network is a query for an openstack network that the port will be created or discovered on.
+                                This will fail if the query returns more than one network.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                filter:
+                                  description: Filter specifies a filter to select
+                                    an OpenStack network. If provided, cannot be empty.
+                                  minProperties: 1
+                                  properties:
+                                    description:
+                                      type: string
+                                    name:
+                                      type: string
+                                    notTags:
+                                      description: |-
+                                        NotTags is a list of tags to filter by. If specified, resources which
+                                        contain all of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    notTagsAny:
+                                      description: |-
+                                        NotTagsAny is a list of tags to filter by. If specified, resources
+                                        which contain any of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    projectID:
+                                      type: string
+                                    tags:
+                                      description: |-
+                                        Tags is a list of tags to filter by. If specified, the resource must
+                                        have all of the tags specified to be included in the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    tagsAny:
+                                      description: |-
+                                        TagsAny is a list of tags to filter by. If specified, the resource
+                                        must have at least one of the tags specified to be included in the
+                                        result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  type: object
+                                id:
+                                  description: ID is the ID of the network to use.
+                                    If ID is provided, the other filters cannot be
+                                    provided. Must be in UUID format.
+                                  format: uuid
+                                  type: string
+                              type: object
+                            profile:
+                              description: |-
+                                Profile is a set of key-value pairs that are used for binding
+                                details. We intentionally don't expose this as a map[string]string
+                                because we only want to enable the users to set the values of the
+                                keys that are known to work in OpenStack Networking API.  See
+                                https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                                To set profiles, your tenant needs permissions rule:create_port, and
+                                rule:create_port:binding:profile
+                              properties:
+                                ovsHWOffload:
+                                  description: |-
+                                    OVSHWOffload enables or disables the OVS hardware offload feature.
+                                    This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                                    See: https://bugs.launchpad.net/nova/+bug/2020813
+                                  type: boolean
+                                trustedVF:
+                                  description: TrustedVF enables or disables the “trusted
+                                    mode” for the VF.
+                                  type: boolean
+                              type: object
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
+                            securityGroups:
+                              description: SecurityGroups is a list of the names,
+                                uuids, filters or any combination these of the security
+                                groups to assign to the instance.
+                              items:
+                                description: SecurityGroupParam specifies an OpenStack
+                                  security group. It may be specified by ID or filter,
+                                  but not both.
+                                maxProperties: 1
+                                minProperties: 1
+                                properties:
+                                  filter:
+                                    description: Filter specifies a query to select
+                                      an OpenStack security group. If provided, cannot
+                                      be empty.
+                                    minProperties: 1
+                                    properties:
+                                      description:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        description: |-
+                                          NotTags is a list of tags to filter by. If specified, resources which
+                                          contain all of the given tags will be excluded from the result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      notTagsAny:
+                                        description: |-
+                                          NotTagsAny is a list of tags to filter by. If specified, resources
+                                          which contain any of the given tags will be excluded from the result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      projectID:
+                                        type: string
+                                      tags:
+                                        description: |-
+                                          Tags is a list of tags to filter by. If specified, the resource must
+                                          have all of the tags specified to be included in the result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      tagsAny:
+                                        description: |-
+                                          TagsAny is a list of tags to filter by. If specified, the resource
+                                          must have at least one of the tags specified to be included in the
+                                          result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  id:
+                                    description: ID is the ID of the security group
+                                      to use. If ID is provided, the other filters
+                                      cannot be provided. Must be in UUID format.
+                                    format: uuid
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            tags:
+                              description: |-
+                                Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                                These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            trunk:
+                              description: |-
+                                Trunk specifies whether trunking is enabled at the port level. If not
+                                provided the value is inherited from the machine, or false for a
+                                bastion host.
+                              type: boolean
+                            valueSpecs:
+                              description: |-
+                                Value specs are extra parameters to include in the API request with OpenStack.
+                                This is an extension point for the API, so what they do and if they are supported,
+                                depends on the specific OpenStack implementation.
+                              items:
+                                description: ValueSpec represents a single value_spec
+                                  key-value pair.
+                                properties:
+                                  key:
+                                    description: Key is the key in the key-value pair.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the key-value pair.
+                                      This is just for identifying the pair and will not be sent to the OpenStack API.
+                                    type: string
+                                  value:
+                                    description: Value is the value in the key-value
+                                      pair.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            vnicType:
+                              description: |-
+                                VNICType specifies the type of vNIC which this port should be
+                                attached to. This is used to determine which mechanism driver(s) to
+                                be used to bind the port. The valid values are normal, macvtap,
+                                direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                                remote-managed, although these values will not be validated in this
+                                API to ensure compatibility with future neutron changes or custom
+                                implementations. What type of vNIC is actually available depends on
+                                deployments. If not specified, the Neutron default value is used.
+                              type: string
+                          type: object
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      rootVolume:
+                        description: The volume metadata to boot from
+                        properties:
+                          availabilityZone:
+                            description: |-
+                              AvailabilityZone is the volume availability zone to create the volume
+                              in. If not specified, the volume will be created without an explicit
+                              availability zone.
+                            properties:
+                              from:
+                                default: Name
+                                description: |-
+                                  From specifies where we will obtain the availability zone for the
+                                  volume. The options are "Name" and "Machine". If "Name" is specified
+                                  then the Name field must also be specified. If "Machine" is specified
+                                  the volume will use the value of FailureDomain, if any, from the
+                                  associated Machine.
+                                enum:
+                                - Name
+                                - Machine
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of a volume availability zone to use. It is required
+                                  if From is "Name". The volume availability zone name may not contain
+                                  spaces.
+                                minLength: 1
+                                pattern: ^[^ ]+$
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: name is required when from is 'Name' or default
+                              rule: '!has(self.from) || self.from == ''Name'' ? has(self.name)
+                                : !has(self.name)'
+                          sizeGiB:
+                            description: SizeGiB is the size of the block device in
+                              gibibytes (GiB).
+                            minimum: 1
+                            type: integer
+                          type:
+                            description: |-
+                              Type is the Cinder volume type of the volume.
+                              If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                              will be used.
+                            type: string
+                        required:
+                        - sizeGiB
+                        type: object
+                      schedulerHintAdditionalProperties:
+                        description: |-
+                          SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints
+                          to the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,
+                          such as specifying certain host aggregates or availability zones.
+                        items:
+                          description: |-
+                            SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.
+                            It includes a Name to identify the property and a Value that can be of various types.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the scheduler hint property.
+                                It is a unique identifier for the property.
+                              minLength: 1
+                              type: string
+                            value:
+                              description: |-
+                                Value is the value of the scheduler hint property, which can be of various types
+                                (e.g., bool, string, int). The type is indicated by the Value.Type field.
+                              properties:
+                                bool:
+                                  description: |-
+                                    Bool is the boolean value of the scheduler hint, used when Type is "Bool".
+                                    This field is required if type is 'Bool', and must not be set otherwise.
+                                  type: boolean
+                                number:
+                                  description: |-
+                                    Number is the integer value of the scheduler hint, used when Type is "Number".
+                                    This field is required if type is 'Number', and must not be set otherwise.
+                                  type: integer
+                                string:
+                                  description: |-
+                                    String is the string value of the scheduler hint, used when Type is "String".
+                                    This field is required if type is 'String', and must not be set otherwise.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type represents the type of the value.
+                                    Valid values are Bool, String, and Number.
+                                  enum:
+                                  - Bool
+                                  - String
+                                  - Number
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: bool is required when type is Bool, and forbidden
+                                  otherwise
+                                rule: 'has(self.type) && self.type == ''Bool'' ? has(self.bool)
+                                  : !has(self.bool)'
+                              - message: number is required when type is Number, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Number'' ?
+                                  has(self.number) : !has(self.number)'
+                              - message: string is required when type is String, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''String'' ?
+                                  has(self.string) : !has(self.string)'
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the instance
+                        items:
+                          description: SecurityGroupParam specifies an OpenStack security
+                            group. It may be specified by ID or filter, but not both.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            filter:
+                              description: Filter specifies a query to select an OpenStack
+                                security group. If provided, cannot be empty.
+                              minProperties: 1
+                              properties:
+                                description:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  description: |-
+                                    NotTags is a list of tags to filter by. If specified, resources which
+                                    contain all of the given tags will be excluded from the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                notTagsAny:
+                                  description: |-
+                                    NotTagsAny is a list of tags to filter by. If specified, resources
+                                    which contain any of the given tags will be excluded from the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                projectID:
+                                  type: string
+                                tags:
+                                  description: |-
+                                    Tags is a list of tags to filter by. If specified, the resource must
+                                    have all of the tags specified to be included in the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                tagsAny:
+                                  description: |-
+                                    TagsAny is a list of tags to filter by. If specified, the resource
+                                    must have at least one of the tags specified to be included in the
+                                    result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                            id:
+                              description: ID is the ID of the security group to use.
+                                If ID is provided, the other filters cannot be provided.
+                                Must be in UUID format.
+                              format: uuid
+                              type: string
+                          type: object
+                        type: array
+                      serverGroup:
+                        description: The server group to assign the machine to.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a query to select an OpenStack
+                              server group. If provided, it cannot be empty.
+                            minProperties: 1
+                            properties:
+                              name:
+                                description: Name is the name of a server group to
+                                  look for.
+                                type: string
+                            type: object
+                          id:
+                            description: ID is the ID of the server group to use.
+                            format: uuid
+                            type: string
+                        type: object
+                      serverMetadata:
+                        description: Metadata mapping. Allows you to create a map
+                          of key value pairs to add to the server instance.
+                        items:
+                          properties:
+                            key:
+                              description: Key is the server metadata key
+                              maxLength: 255
+                              type: string
+                            value:
+                              description: Value is the server metadata value
+                              maxLength: 255
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      sshKeyName:
+                        description: The ssh key to inject in the instance
+                        type: string
+                      tags:
+                        description: |-
+                          Tags which will be added to the machine and all dependent resources
+                          which support them. These are in addition to Tags defined on the
+                          cluster.
+                          Requires Nova api 2.52 minimum!
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      trunk:
+                        description: Whether the server instance is created on a trunk
+                          port or not.
+                        type: boolean
+                    required:
+                    - image
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of flavor or flavorID must be set
+                      rule: (has(self.flavor) || has(self.flavorID))
+                type: object
+                x-kubernetes-validations:
+                - message: spec is required if bastion is enabled
+                  rule: '!self.enabled || has(self.spec)'
+              controlPlaneAvailabilityZones:
+                description: |-
+                  ControlPlaneAvailabilityZones is the set of availability zones which
+                  control plane machines may be deployed to.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              controlPlaneEndpoint:
+                description: |-
+                  ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                  It is normally populated automatically by the OpenStackCluster
+                  controller during cluster provisioning. If it is set on creation the
+                  control plane endpoint will use the values set here in preference to
+                  values set elsewhere.
+                  ControlPlaneEndpoint cannot be modified after ControlPlaneEndpoint.Host has been set.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneOmitAvailabilityZone:
+                description: |-
+                  ControlPlaneOmitAvailabilityZone causes availability zone to be
+                  omitted when creating control plane nodes, allowing the Nova
+                  scheduler to make a decision on which availability zone to use based
+                  on other scheduling constraints
+                type: boolean
+              disableAPIServerFloatingIP:
+                description: |-
+                  DisableAPIServerFloatingIP determines whether or not to attempt to attach a floating
+                  IP to the API server. This allows for the creation of clusters when attaching a floating
+                  IP to the API server (and hence, in many cases, exposing the API server to the internet)
+                  is not possible or desirable, e.g. if using a shared VLAN for communication between
+                  management and workload clusters or when the management cluster is inside the
+                  project network.
+                  This option requires that the API server use a VIP on the cluster network so that the
+                  underlying machines can change without changing ControlPlaneEndpoint.Host.
+                  When using a managed load balancer, this VIP will be managed automatically.
+                  If not using a managed load balancer, cluster configuration will fail without additional
+                  configuration to manage the VIP on the control plane machines, which falls outside of
+                  the scope of this controller.
+                type: boolean
+              disableExternalNetwork:
+                description: |-
+                  DisableExternalNetwork specifies whether or not to attempt to connect the cluster
+                  to an external network. This allows for the creation of clusters when connecting
+                  to an external network is not possible or desirable, e.g. if using a provider network.
+                type: boolean
+              disablePortSecurity:
+                description: |-
+                  DisablePortSecurity disables the port security of the network created for the
+                  Kubernetes cluster, which also disables SecurityGroups
+                type: boolean
+              externalNetwork:
+                description: |-
+                  ExternalNetwork is the OpenStack Network to be used to get public internet to the VMs.
+                  This option is ignored if DisableExternalNetwork is set to true.
+
+                  If ExternalNetwork is defined it must refer to exactly one external network.
+
+                  If ExternalNetwork is not defined or is empty the controller will use any
+                  existing external network as long as there is only one. It is an
+                  error if ExternalNetwork is not defined and there are multiple
+                  external networks unless DisableExternalNetwork is also set.
+
+                  If ExternalNetwork is not defined and there are no external networks
+                  the controller will proceed as though DisableExternalNetwork was set.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a filter to select an OpenStack
+                      network. If provided, cannot be empty.
+                    minProperties: 1
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                      notTags:
+                        description: |-
+                          NotTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          NotTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      projectID:
+                        type: string
+                      tags:
+                        description: |-
+                          Tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          TagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the ID of the network to use. If ID is provided,
+                      the other filters cannot be provided. Must be in UUID format.
+                    format: uuid
+                    type: string
+                type: object
+              externalRouterIPs:
+                description: |-
+                  ExternalRouterIPs is an array of externalIPs on the respective subnets.
+                  This is necessary if the router needs a fixed ip in a specific subnet.
+                items:
+                  properties:
+                    fixedIP:
+                      description: The FixedIP in the corresponding subnet
+                      type: string
+                    subnet:
+                      description: The subnet in which the FixedIP is used for the
+                        Gateway of this router
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        filter:
+                          description: Filter specifies a filter to select the subnet.
+                            It must match exactly one subnet.
+                          minProperties: 1
+                          properties:
+                            cidr:
+                              type: string
+                            description:
+                              type: string
+                            gatewayIP:
+                              type: string
+                            ipVersion:
+                              type: integer
+                            ipv6AddressMode:
+                              type: string
+                            ipv6RAMode:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              description: |-
+                                NotTags is a list of tags to filter by. If specified, resources which
+                                contain all of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            notTagsAny:
+                              description: |-
+                                NotTagsAny is a list of tags to filter by. If specified, resources
+                                which contain any of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            projectID:
+                              type: string
+                            tags:
+                              description: |-
+                                Tags is a list of tags to filter by. If specified, the resource must
+                                have all of the tags specified to be included in the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            tagsAny:
+                              description: |-
+                                TagsAny is a list of tags to filter by. If specified, the resource
+                                must have at least one of the tags specified to be included in the
+                                result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          type: object
+                        id:
+                          description: ID is the uuid of the subnet. It will not be
+                            validated.
+                          format: uuid
+                          type: string
+                      type: object
+                  required:
+                  - subnet
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              identityRef:
+                description: |-
+                  IdentityRef is a reference to a secret holding OpenStack credentials
+                  to be used when reconciling this cluster. It is also to reconcile
+                  machines unless overridden in the machine spec.
+                properties:
+                  cloudName:
+                    description: CloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
+                required:
+                - cloudName
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
+              managedSecurityGroups:
+                description: |-
+                  ManagedSecurityGroups determines whether OpenStack security groups for the cluster
+                  will be managed by the OpenStack provider or whether pre-existing security groups will
+                  be specified as part of the configuration.
+                  By default, the managed security groups have rules that allow the Kubelet, etcd, and the
+                  Kubernetes API server to function correctly.
+                  It's possible to add additional rules to the managed security groups.
+                  When defined to an empty struct, the managed security groups will be created with the default rules.
+                properties:
+                  allNodesSecurityGroupRules:
+                    description: allNodesSecurityGroupRules defines the rules that
+                      should be applied to all nodes.
+                    items:
+                      description: |-
+                        SecurityGroupRuleSpec represent the basic information of the associated OpenStack
+                        Security Group Role.
+                        For now this is only used for the allNodesSecurityGroupRules but when we add
+                        other security groups, we'll need to add a validation because
+                        Remote* fields are mutually exclusive.
+                      properties:
+                        description:
+                          description: description of the security group rule.
+                          type: string
+                        direction:
+                          description: |-
+                            direction in which the security group rule is applied. The only values
+                            allowed are "ingress" or "egress". For a compute instance, an ingress
+                            security group rule is applied to incoming (ingress) traffic for that
+                            instance. An egress rule is applied to traffic leaving the instance.
+                          type: string
+                        etherType:
+                          description: |-
+                            etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the
+                            ingress or egress rules.
+                          type: string
+                        name:
+                          description: |-
+                            name of the security group rule.
+                            It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
+                          type: string
+                        portRangeMax:
+                          description: |-
+                            portRangeMax is a number in the range that is matched by the security group
+                            rule. The portRangeMin attribute constrains the portRangeMax attribute.
+                          type: integer
+                        portRangeMin:
+                          description: |-
+                            portRangeMin is a number in the range that is matched by the security group
+                            rule. If the protocol is TCP or UDP, this value must be less than or equal
+                            to the value of the portRangeMax attribute.
+                          type: integer
+                        protocol:
+                          description: protocol is the protocol that is matched by
+                            the security group rule.
+                          type: string
+                        remoteGroupID:
+                          description: |-
+                            remoteGroupID is the remote group ID to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          type: string
+                        remoteIPPrefix:
+                          description: |-
+                            remoteIPPrefix is the remote IP prefix to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          type: string
+                        remoteManagedGroups:
+                          description: |-
+                            remoteManagedGroups is the remote managed groups to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          items:
+                            enum:
+                            - bastion
+                            - controlplane
+                            - worker
+                            type: string
+                          type: array
+                      required:
+                      - direction
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  allowAllInClusterTraffic:
+                    default: false
+                    description: AllowAllInClusterTraffic allows all ingress and egress
+                      traffic between cluster nodes when set to true.
+                    type: boolean
+                  controlPlaneNodesSecurityGroupRules:
+                    description: controlPlaneNodesSecurityGroupRules defines the rules
+                      that should be applied to control plane nodes.
+                    items:
+                      description: |-
+                        SecurityGroupRuleSpec represent the basic information of the associated OpenStack
+                        Security Group Role.
+                        For now this is only used for the allNodesSecurityGroupRules but when we add
+                        other security groups, we'll need to add a validation because
+                        Remote* fields are mutually exclusive.
+                      properties:
+                        description:
+                          description: description of the security group rule.
+                          type: string
+                        direction:
+                          description: |-
+                            direction in which the security group rule is applied. The only values
+                            allowed are "ingress" or "egress". For a compute instance, an ingress
+                            security group rule is applied to incoming (ingress) traffic for that
+                            instance. An egress rule is applied to traffic leaving the instance.
+                          type: string
+                        etherType:
+                          description: |-
+                            etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the
+                            ingress or egress rules.
+                          type: string
+                        name:
+                          description: |-
+                            name of the security group rule.
+                            It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
+                          type: string
+                        portRangeMax:
+                          description: |-
+                            portRangeMax is a number in the range that is matched by the security group
+                            rule. The portRangeMin attribute constrains the portRangeMax attribute.
+                          type: integer
+                        portRangeMin:
+                          description: |-
+                            portRangeMin is a number in the range that is matched by the security group
+                            rule. If the protocol is TCP or UDP, this value must be less than or equal
+                            to the value of the portRangeMax attribute.
+                          type: integer
+                        protocol:
+                          description: protocol is the protocol that is matched by
+                            the security group rule.
+                          type: string
+                        remoteGroupID:
+                          description: |-
+                            remoteGroupID is the remote group ID to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          type: string
+                        remoteIPPrefix:
+                          description: |-
+                            remoteIPPrefix is the remote IP prefix to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          type: string
+                        remoteManagedGroups:
+                          description: |-
+                            remoteManagedGroups is the remote managed groups to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          items:
+                            enum:
+                            - bastion
+                            - controlplane
+                            - worker
+                            type: string
+                          type: array
+                      required:
+                      - direction
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  workerNodesSecurityGroupRules:
+                    description: workerNodesSecurityGroupRules defines the rules that
+                      should be applied to worker nodes.
+                    items:
+                      description: |-
+                        SecurityGroupRuleSpec represent the basic information of the associated OpenStack
+                        Security Group Role.
+                        For now this is only used for the allNodesSecurityGroupRules but when we add
+                        other security groups, we'll need to add a validation because
+                        Remote* fields are mutually exclusive.
+                      properties:
+                        description:
+                          description: description of the security group rule.
+                          type: string
+                        direction:
+                          description: |-
+                            direction in which the security group rule is applied. The only values
+                            allowed are "ingress" or "egress". For a compute instance, an ingress
+                            security group rule is applied to incoming (ingress) traffic for that
+                            instance. An egress rule is applied to traffic leaving the instance.
+                          type: string
+                        etherType:
+                          description: |-
+                            etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the
+                            ingress or egress rules.
+                          type: string
+                        name:
+                          description: |-
+                            name of the security group rule.
+                            It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
+                          type: string
+                        portRangeMax:
+                          description: |-
+                            portRangeMax is a number in the range that is matched by the security group
+                            rule. The portRangeMin attribute constrains the portRangeMax attribute.
+                          type: integer
+                        portRangeMin:
+                          description: |-
+                            portRangeMin is a number in the range that is matched by the security group
+                            rule. If the protocol is TCP or UDP, this value must be less than or equal
+                            to the value of the portRangeMax attribute.
+                          type: integer
+                        protocol:
+                          description: protocol is the protocol that is matched by
+                            the security group rule.
+                          type: string
+                        remoteGroupID:
+                          description: |-
+                            remoteGroupID is the remote group ID to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          type: string
+                        remoteIPPrefix:
+                          description: |-
+                            remoteIPPrefix is the remote IP prefix to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          type: string
+                        remoteManagedGroups:
+                          description: |-
+                            remoteManagedGroups is the remote managed groups to be associated with this security group rule.
+                            You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                          items:
+                            enum:
+                            - bastion
+                            - controlplane
+                            - worker
+                            type: string
+                          type: array
+                      required:
+                      - direction
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - allowAllInClusterTraffic
+                type: object
+              managedSubnets:
+                description: |-
+                  ManagedSubnets describe OpenStack Subnets to be created. Cluster actuator will create a network,
+                  subnets with the defined CIDR, and a router connected to these subnets. Currently only one IPv4
+                  subnet is supported. If you leave this empty, no network will be created.
+                items:
+                  properties:
+                    allocationPools:
+                      description: |-
+                        AllocationPools is an array of AllocationPool objects that will be applied to OpenStack Subnet being created.
+                        If set, OpenStack will only allocate these IPs for Machines. It will still be possible to create ports from
+                        outside of these ranges manually.
+                      items:
+                        properties:
+                          end:
+                            description: End represents the end of the AlloctionPool,
+                              that is the highest IP of the pool.
+                            type: string
+                          start:
+                            description: Start represents the start of the AllocationPool,
+                              that is the lowest IP of the pool.
+                            type: string
+                        required:
+                        - end
+                        - start
+                        type: object
+                      type: array
+                    cidr:
+                      description: |-
+                        CIDR is representing the IP address range used to create the subnet, e.g. 10.0.0.0/24.
+                        This field is required when defining a subnet.
+                      type: string
+                    dnsNameservers:
+                      description: |-
+                        DNSNameservers holds a list of DNS server addresses that will be provided when creating
+                        the subnet. These addresses need to have the same IP version as CIDR.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                maxItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              network:
+                description: |-
+                  Network specifies an existing network to use if no ManagedSubnets
+                  are specified.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a filter to select an OpenStack
+                      network. If provided, cannot be empty.
+                    minProperties: 1
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                      notTags:
+                        description: |-
+                          NotTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          NotTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      projectID:
+                        type: string
+                      tags:
+                        description: |-
+                          Tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          TagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the ID of the network to use. If ID is provided,
+                      the other filters cannot be provided. Must be in UUID format.
+                    format: uuid
+                    type: string
+                type: object
+              networkMTU:
+                description: |-
+                  NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
+                  This value will be used only if the Cluster actuator creates the network.
+                  If left empty, the network will have the default MTU defined in Openstack network service.
+                  To use this field, the Openstack installation requires the net-mtu neutron API extension.
+                type: integer
+              router:
+                description: |-
+                  Router specifies an existing router to be used if ManagedSubnets are
+                  specified. If specified, no new router will be created.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a filter to select an OpenStack
+                      router. If provided, cannot be empty.
+                    minProperties: 1
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                      notTags:
+                        description: |-
+                          NotTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          NotTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      projectID:
+                        type: string
+                      tags:
+                        description: |-
+                          Tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          TagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the ID of the router to use. If ID is provided,
+                      the other filters cannot be provided. Must be in UUID format.
+                    format: uuid
+                    type: string
+                type: object
+              subnets:
+                description: |-
+                  Subnets specifies existing subnets to use if not ManagedSubnets are
+                  specified. All subnets must be in the network specified by Network.
+                  There can be zero, one, or two subnets. If no subnets are specified,
+                  all subnets in Network will be used. If 2 subnets are specified, one
+                  must be IPv4 and the other IPv6.
+                items:
+                  description: SubnetParam specifies an OpenStack subnet to use. It
+                    may be specified by either ID or filter, but not both.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: Filter specifies a filter to select the subnet.
+                        It must match exactly one subnet.
+                      minProperties: 1
+                      properties:
+                        cidr:
+                          type: string
+                        description:
+                          type: string
+                        gatewayIP:
+                          type: string
+                        ipVersion:
+                          type: integer
+                        ipv6AddressMode:
+                          type: string
+                        ipv6RAMode:
+                          type: string
+                        name:
+                          type: string
+                        notTags:
+                          description: |-
+                            NotTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            NotTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        projectID:
+                          type: string
+                        tags:
+                          description: |-
+                            Tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            TagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: ID is the uuid of the subnet. It will not be validated.
+                      format: uuid
+                      type: string
+                  type: object
+                maxItems: 2
+                type: array
+                x-kubernetes-list-type: atomic
+              tags:
+                description: Tags to set on all resources in cluster which support
+                  tags
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - identityRef
+            type: object
+            x-kubernetes-validations:
+            - message: bastion floating IP cannot be set when disableExternalNetwork
+                is true
+              rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+                ? !has(self.bastion) || !has(self.bastion.floatingIP) : true'
+            - message: disableAPIServerFloatingIP cannot be false when disableExternalNetwork
+                is true
+              rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+                ? has(self.disableAPIServerFloatingIP) && self.disableAPIServerFloatingIP
+                : true'
+          status:
+            description: OpenStackClusterStatus defines the observed state of OpenStackCluster.
+            properties:
+              apiServerLoadBalancer:
+                description: APIServerLoadBalancer describes the api server load balancer
+                  if one exists
+                properties:
+                  allowedCIDRs:
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    type: string
+                  internalIP:
+                    type: string
+                  ip:
+                    type: string
+                  loadBalancerNetwork:
+                    description: |-
+                      LoadBalancerNetwork contains information about network and/or subnets which the
+                      loadbalancer is allocated on.
+                      If subnets are specified within the LoadBalancerNetwork currently only the first
+                      subnet in the list is taken into account.
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      subnets:
+                        description: Subnets is a list of subnets associated with
+                          the default cluster network. Machines which use the default
+                          cluster network will get an address from all of these subnets.
+                        items:
+                          description: Subnet represents basic information about the
+                            associated OpenStack Neutron Subnet.
+                          properties:
+                            cidr:
+                              type: string
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            tags:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - cidr
+                          - id
+                          - name
+                          type: object
+                        type: array
+                      tags:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - id
+                    - name
+                    type: object
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - internalIP
+                - ip
+                - name
+                type: object
+              bastion:
+                description: Bastion contains the information about the deployed bastion
+                  host
+                properties:
+                  floatingIP:
+                    type: string
+                  id:
+                    type: string
+                  ip:
+                    type: string
+                  name:
+                    type: string
+                  resolved:
+                    description: |-
+                      Resolved contains parts of the bastion's machine spec with all
+                      external references fully resolved.
+                    properties:
+                      flavorID:
+                        description: FlavorID is the ID of the flavor to use.
+                        type: string
+                      imageID:
+                        description: ImageID is the ID of the image to use for the
+                          machine and is calculated based on ImageFilter.
+                        type: string
+                      ports:
+                        description: Ports is the fully resolved list of ports to
+                          create for the machine.
+                        items:
+                          description: ResolvedPortSpec is a PortOpts with all contained
+                            references fully resolved.
+                          properties:
+                            adminStateUp:
+                              description: AdminStateUp specifies whether the port
+                                should be created in the up (true) or down (false)
+                                state. The default is up.
+                              type: boolean
+                            allowedAddressPairs:
+                              description: |-
+                                AllowedAddressPairs is a list of address pairs which Neutron will
+                                allow the port to send traffic from in addition to the port's
+                                addresses. If not specified, the MAC Address will be the MAC Address
+                                of the port. Depending on the configuration of Neutron, it may be
+                                supported to specify a CIDR instead of a specific IP address.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    description: |-
+                                      IPAddress is the IP address of the allowed address pair. Depending on
+                                      the configuration of Neutron, it may be supported to specify a CIDR
+                                      instead of a specific IP address.
+                                    type: string
+                                  macAddress:
+                                    description: |-
+                                      MACAddress is the MAC address of the allowed address pair. If not
+                                      specified, the MAC address will be the MAC address of the port.
+                                    type: string
+                                required:
+                                - ipAddress
+                                type: object
+                              type: array
+                            description:
+                              description: Description is a human-readable description
+                                for the port.
+                              type: string
+                            disablePortSecurity:
+                              description: |-
+                                DisablePortSecurity enables or disables the port security when set.
+                                When not set, it takes the value of the corresponding field at the network level.
+                              type: boolean
+                            fixedIPs:
+                              description: FixedIPs is a list of pairs of subnet and/or
+                                IP address to assign to the port. If specified, these
+                                must be subnets of the port's network.
+                              items:
+                                description: ResolvedFixedIP is a FixedIP with the
+                                  Subnet resolved to an ID.
+                                properties:
+                                  ipAddress:
+                                    description: |-
+                                      IPAddress is a specific IP address to assign to the port. If SubnetID
+                                      is also specified, IPAddress must be a valid IP address in the
+                                      subnet. If Subnet is not specified, IPAddress must be a valid IP
+                                      address in any subnet of the port's network.
+                                    type: string
+                                  subnet:
+                                    description: SubnetID is the id of a subnet to
+                                      create the fixed IP of a port in.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            hostID:
+                              description: HostID specifies the ID of the host where
+                                the port resides.
+                              type: string
+                            macAddress:
+                              description: MACAddress specifies the MAC address of
+                                the port. If not specified, the MAC address will be
+                                generated.
+                              type: string
+                            name:
+                              description: Name is the name of the port.
+                              type: string
+                            networkID:
+                              description: NetworkID is the ID of the network the
+                                port will be created in.
+                              type: string
+                            profile:
+                              description: |-
+                                Profile is a set of key-value pairs that are used for binding
+                                details. We intentionally don't expose this as a map[string]string
+                                because we only want to enable the users to set the values of the
+                                keys that are known to work in OpenStack Networking API.  See
+                                https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                                To set profiles, your tenant needs permissions rule:create_port, and
+                                rule:create_port:binding:profile
+                              properties:
+                                ovsHWOffload:
+                                  description: |-
+                                    OVSHWOffload enables or disables the OVS hardware offload feature.
+                                    This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                                    See: https://bugs.launchpad.net/nova/+bug/2020813
+                                  type: boolean
+                                trustedVF:
+                                  description: TrustedVF enables or disables the “trusted
+                                    mode” for the VF.
+                                  type: boolean
+                              type: object
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
+                            securityGroups:
+                              description: SecurityGroups is a list of security group
+                                IDs to assign to the port.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            tags:
+                              description: Tags applied to the port (and corresponding
+                                trunk, if a trunk is configured.)
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            trunk:
+                              description: Trunk specifies whether trunking is enabled
+                                at the port level.
+                              type: boolean
+                            valueSpecs:
+                              description: |-
+                                Value specs are extra parameters to include in the API request with OpenStack.
+                                This is an extension point for the API, so what they do and if they are supported,
+                                depends on the specific OpenStack implementation.
+                              items:
+                                description: ValueSpec represents a single value_spec
+                                  key-value pair.
+                                properties:
+                                  key:
+                                    description: Key is the key in the key-value pair.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the key-value pair.
+                                      This is just for identifying the pair and will not be sent to the OpenStack API.
+                                    type: string
+                                  value:
+                                    description: Value is the value in the key-value
+                                      pair.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            vnicType:
+                              description: |-
+                                VNICType specifies the type of vNIC which this port should be
+                                attached to. This is used to determine which mechanism driver(s) to
+                                be used to bind the port. The valid values are normal, macvtap,
+                                direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                                remote-managed, although these values will not be validated in this
+                                API to ensure compatibility with future neutron changes or custom
+                                implementations. What type of vNIC is actually available depends on
+                                deployments. If not specified, the Neutron default value is used.
+                              type: string
+                          required:
+                          - description
+                          - name
+                          - networkID
+                          type: object
+                        type: array
+                      serverGroupID:
+                        description: ServerGroupID is the ID of the server group the
+                          machine should be added to and is calculated based on ServerGroupFilter.
+                        type: string
+                    type: object
+                  resources:
+                    description: Resources contains references to OpenStack resources
+                      created for the bastion.
+                    properties:
+                      ports:
+                        description: Ports is the status of the ports created for
+                          the machine.
+                        items:
+                          properties:
+                            id:
+                              description: ID is the unique identifier of the port.
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                    type: object
+                  sshKeyName:
+                    type: string
+                  state:
+                    description: InstanceState describes the state of an OpenStack
+                      instance.
+                    type: string
+                type: object
+              bastionSecurityGroup:
+                description: |-
+                  BastionSecurityGroup contains the information about the OpenStack
+                  Security Group that needs to be applied to worker nodes.
+                properties:
+                  id:
+                    description: id of the security group
+                    type: string
+                  name:
+                    description: name of the security group
+                    type: string
+                required:
+                - id
+                - name
+                type: object
+              controlPlaneSecurityGroup:
+                description: |-
+                  ControlPlaneSecurityGroup contains the information about the
+                  OpenStack Security Group that needs to be applied to control plane
+                  nodes.
+                properties:
+                  id:
+                    description: id of the security group
+                    type: string
+                  name:
+                    description: name of the security group
+                    type: string
+                required:
+                - id
+                - name
+                type: object
+              externalNetwork:
+                description: ExternalNetwork contains information about the external
+                  network used for default ingress and egress traffic.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains represent OpenStack availability zones
+                type: object
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the OpenStackCluster and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the OpenStackCluster's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of
+                  OpenStackClusters can be added as events to the OpenStackCluster object
+                  and/or logged in the controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the OpenStackCluster and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the OpenStackCluster's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of
+                  OpenStackClusters can be added as events to the OpenStackCluster object
+                  and/or logged in the controller's output.
+                type: string
+              network:
+                description: Network contains information about the created OpenStack
+                  Network.
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  subnets:
+                    description: Subnets is a list of subnets associated with the
+                      default cluster network. Machines which use the default cluster
+                      network will get an address from all of these subnets.
+                    items:
+                      description: Subnet represents basic information about the associated
+                        OpenStack Neutron Subnet.
+                      properties:
+                        cidr:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        tags:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                      - id
+                      - name
+                      type: object
+                    type: array
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              ready:
+                default: false
+                description: Ready is true when the cluster infrastructure is ready.
+                type: boolean
+              router:
+                description: Router describes the default cluster router
+                properties:
+                  id:
+                    type: string
+                  ips:
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+              workerSecurityGroup:
+                description: |-
+                  WorkerSecurityGroup contains the information about the OpenStack
+                  Security Group that needs to be applied to worker nodes.
+                properties:
+                  id:
+                    description: id of the security group
+                    type: string
+                  name:
+                    description: name of the security group
+                    type: string
+                required:
+                - id
+                - name
+                type: object
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    cluster.x-k8s.io/v1beta1: v1alpha7_v1beta1
+  name: openstackclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capo-webhook-service
+          namespace: capo-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OpenStackClusterTemplate
+    listKind: OpenStackClusterTemplateList
+    plural: openstackclustertemplates
+    shortNames:
+    - osct
+    singular: openstackclustertemplate
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: The v1alpha7 version of OpenStackClusterTemplate has been
+      deprecated and will be removed in a future release.
+    name: v1alpha7
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OpenStackClusterTemplate is the Schema for the openstackclustertemplates API.
+
+          Deprecated: v1alpha7.OpenStackClusterTemplate has been replaced by v1beta1.OpenStackClusterTemplate.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackClusterTemplateSpec defines the desired state of
+              OpenStackClusterTemplate.
+            properties:
+              template:
+                description: OpenStackClusterTemplateResource describes the data needed
+                  to create a OpenStackCluster from a template.
+                properties:
+                  spec:
+                    description: OpenStackClusterSpec defines the desired state of
+                      OpenStackCluster.
+                    properties:
+                      allowAllInClusterTraffic:
+                        description: |-
+                          AllowAllInClusterTraffic is only used when managed security groups are in use.
+                          If set to true, the rules for the managed security groups are configured so that all
+                          ingress and egress between cluster nodes is permitted, allowing CNIs other than
+                          Calico to be used.
+                        type: boolean
+                      apiServerFixedIP:
+                        description: |-
+                          APIServerFixedIP is the fixed IP which will be associated with the API server.
+                          In the case where the API server has a floating IP but not a managed load balancer,
+                          this field is not used.
+                          If a managed load balancer is used and this field is not specified, a fixed IP will
+                          be dynamically allocated for the load balancer.
+                          If a managed load balancer is not used AND the API server floating IP is disabled,
+                          this field MUST be specified and should correspond to a pre-allocated port that
+                          holds the fixed IP to be used as a VIP.
+                        type: string
+                      apiServerFloatingIP:
+                        description: |-
+                          APIServerFloatingIP is the floatingIP which will be associated with the API server.
+                          The floatingIP will be created if it does not already exist.
+                          If not specified, a new floatingIP is allocated.
+                          This field is not used if DisableAPIServerFloatingIP is set to true.
+                        type: string
+                      apiServerLoadBalancer:
+                        description: |-
+                          APIServerLoadBalancer configures the optional LoadBalancer for the APIServer.
+                          It must be activated by setting `enabled: true`.
+                        properties:
+                          additionalPorts:
+                            description: AdditionalPorts adds additional tcp ports
+                              to the load balancer.
+                            items:
+                              type: integer
+                            type: array
+                          allowedCidrs:
+                            description: AllowedCIDRs restrict access to all API-Server
+                              listeners to the given address CIDRs.
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            description: Enabled defines whether a load balancer should
+                              be created.
+                            type: boolean
+                          provider:
+                            description: Octavia Provider Used to create load balancer
+                            type: string
+                        type: object
+                      apiServerPort:
+                        description: |-
+                          APIServerPort is the port on which the listener on the APIServer
+                          will be created
+                        type: integer
+                      bastion:
+                        description: |-
+                          Bastion is the OpenStack instance to login the nodes
+
+                          As a rolling update is not ideal during a bastion host session, we
+                          prevent changes to a running bastion configuration. Set `enabled: false` to
+                          make changes.
+                        properties:
+                          availabilityZone:
+                            type: string
+                          enabled:
+                            type: boolean
+                          instance:
+                            description: Instance for the bastion itself
+                            properties:
+                              additionalBlockDevices:
+                                description: AdditionalBlockDevices is a list of specifications
+                                  for additional block devices to attach to the server
+                                  instance
+                                items:
+                                  description: AdditionalBlockDevice is a block device
+                                    to attach to the server.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the block device in the context of a machine.
+                                        If the block device is a volume, the Cinder volume will be named
+                                        as a combination of the machine name and this name.
+                                        Also, this name will be used for tagging the block device.
+                                        Information about the block device tag can be obtained from the OpenStack
+                                        metadata API or the config drive.
+                                      type: string
+                                    sizeGiB:
+                                      description: SizeGiB is the size of the block
+                                        device in gibibytes (GiB).
+                                      type: integer
+                                    storage:
+                                      description: |-
+                                        Storage specifies the storage type of the block device and
+                                        additional storage options.
+                                      properties:
+                                        type:
+                                          description: |-
+                                            Type is the type of block device to create.
+                                            This can be either "Volume" or "Local".
+                                          type: string
+                                        volume:
+                                          description: Volume contains additional
+                                            storage options for a volume block device.
+                                          properties:
+                                            availabilityZone:
+                                              description: |-
+                                                AvailabilityZone is the volume availability zone to create the volume in.
+                                                If omitted, the availability zone of the server will be used.
+                                                The availability zone must NOT contain spaces otherwise it will lead to volume that belongs
+                                                to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for
+                                                further information.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                Type is the Cinder volume type of the volume.
+                                                If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                                will be used.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - sizeGiB
+                                  - storage
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              cloudName:
+                                description: The name of the cloud to use from the
+                                  clouds secret
+                                type: string
+                              configDrive:
+                                description: Config Drive support
+                                type: boolean
+                              flavor:
+                                description: The flavor reference for the flavor for
+                                  your server instance.
+                                minLength: 1
+                                type: string
+                              flavorID:
+                                description: |-
+                                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                                  over Flavor.
+                                minLength: 1
+                                type: string
+                              floatingIP:
+                                description: |-
+                                  The floatingIP which will be associated to the machine, only used for master.
+                                  The floatingIP should have been created and haven't been associated.
+                                type: string
+                              identityRef:
+                                description: |-
+                                  IdentityRef is a reference to a identity to be used when reconciling this cluster.
+                                  If not specified, the identity ref of the cluster will be used instead.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind of the identity. Must be supported by the infrastructure
+                                      provider and may be either cluster or namespace-scoped.
+                                    minLength: 1
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the infrastructure identity to be used.
+                                      Must be either a cluster-scoped resource, or namespaced-scoped
+                                      resource the same namespace as the resource(s) being provisioned.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              image:
+                                description: |-
+                                  The name of the image to use for your server instance.
+                                  If the RootVolume is specified, this will be ignored and use rootVolume directly.
+                                type: string
+                              imageUUID:
+                                description: |-
+                                  The uuid of the image to use for your server instance.
+                                  if it's empty, Image name will be used
+                                type: string
+                              instanceID:
+                                description: InstanceID is the OpenStack instance
+                                  ID for this machine.
+                                type: string
+                              ports:
+                                description: |-
+                                  Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                                  If not specified a default port will be added for the default cluster network.
+                                items:
+                                  properties:
+                                    adminStateUp:
+                                      type: boolean
+                                    allowedAddressPairs:
+                                      items:
+                                        properties:
+                                          ipAddress:
+                                            type: string
+                                          macAddress:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    description:
+                                      type: string
+                                    disablePortSecurity:
+                                      description: |-
+                                        DisablePortSecurity enables or disables the port security when set.
+                                        When not set, it takes the value of the corresponding field at the network level.
+                                      type: boolean
+                                    fixedIPs:
+                                      description: Specify pairs of subnet and/or
+                                        IP address. These should be subnets of the
+                                        network with the given NetworkID.
+                                      items:
+                                        properties:
+                                          ipAddress:
+                                            type: string
+                                          subnet:
+                                            description: |-
+                                              Subnet is an openstack subnet query that will return the id of a subnet to create
+                                              the fixed IP of a port in. This query must not return more than one subnet.
+                                            properties:
+                                              cidr:
+                                                type: string
+                                              description:
+                                                type: string
+                                              gateway_ip:
+                                                type: string
+                                              id:
+                                                type: string
+                                              ipVersion:
+                                                type: integer
+                                              ipv6AddressMode:
+                                                type: string
+                                              ipv6RaMode:
+                                                type: string
+                                              name:
+                                                type: string
+                                              notTags:
+                                                type: string
+                                              notTagsAny:
+                                                type: string
+                                              projectId:
+                                                type: string
+                                              tags:
+                                                type: string
+                                              tagsAny:
+                                                type: string
+                                            type: object
+                                        required:
+                                        - subnet
+                                        type: object
+                                      type: array
+                                    hostId:
+                                      description: The ID of the host where the port
+                                        is allocated
+                                      type: string
+                                    macAddress:
+                                      type: string
+                                    nameSuffix:
+                                      description: Used to make the name of the port
+                                        unique. If unspecified, instead the 0-based
+                                        index of the port in the list is used.
+                                      type: string
+                                    network:
+                                      description: |-
+                                        Network is a query for an openstack network that the port will be created or discovered on.
+                                        This will fail if the query returns more than one network.
+                                      properties:
+                                        description:
+                                          type: string
+                                        id:
+                                          type: string
+                                        name:
+                                          type: string
+                                        notTags:
+                                          type: string
+                                        notTagsAny:
+                                          type: string
+                                        projectId:
+                                          type: string
+                                        tags:
+                                          type: string
+                                        tagsAny:
+                                          type: string
+                                      type: object
+                                    profile:
+                                      description: |-
+                                        Profile is a set of key-value pairs that are used for binding details.
+                                        We intentionally don't expose this as a map[string]string because we only want to enable
+                                        the users to set the values of the keys that are known to work in OpenStack Networking API.
+                                        See https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                                      properties:
+                                        ovsHWOffload:
+                                          description: OVSHWOffload enables or disables
+                                            the OVS hardware offload feature.
+                                          type: boolean
+                                        trustedVF:
+                                          description: TrustedVF enables or disables
+                                            the “trusted mode” for the VF.
+                                          type: boolean
+                                      type: object
+                                    propagateUplinkStatus:
+                                      description: PropageteUplinkStatus enables or
+                                        disables the propagate uplink status on the
+                                        port.
+                                      type: boolean
+                                    securityGroupFilters:
+                                      description: The names, uuids, filters or any
+                                        combination these of the security groups to
+                                        assign to the instance
+                                      items:
+                                        properties:
+                                          description:
+                                            type: string
+                                          id:
+                                            type: string
+                                          name:
+                                            type: string
+                                          notTags:
+                                            type: string
+                                          notTagsAny:
+                                            type: string
+                                          projectId:
+                                            type: string
+                                          tags:
+                                            type: string
+                                          tagsAny:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tags:
+                                      description: |-
+                                        Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                                        These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    trunk:
+                                      description: Enables and disables trunk at port
+                                        level. If not provided, openStackMachine.Spec.Trunk
+                                        is inherited.
+                                      type: boolean
+                                    valueSpecs:
+                                      description: |-
+                                        Value specs are extra parameters to include in the API request with OpenStack.
+                                        This is an extension point for the API, so what they do and if they are supported,
+                                        depends on the specific OpenStack implementation.
+                                      items:
+                                        description: ValueSpec represents a single
+                                          value_spec key-value pair.
+                                        properties:
+                                          key:
+                                            description: Key is the key in the key-value
+                                              pair.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              Name is the name of the key-value pair.
+                                              This is just for identifying the pair and will not be sent to the OpenStack API.
+                                            type: string
+                                          value:
+                                            description: Value is the value in the
+                                              key-value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    vnicType:
+                                      description: The virtual network interface card
+                                        (vNIC) type that is bound to the neutron port.
+                                      type: string
+                                  type: object
+                                type: array
+                              providerID:
+                                description: ProviderID is the unique identifier as
+                                  specified by the cloud provider.
+                                type: string
+                              rootVolume:
+                                description: The volume metadata to boot from
+                                properties:
+                                  availabilityZone:
+                                    type: string
+                                  diskSize:
+                                    type: integer
+                                  volumeType:
+                                    type: string
+                                type: object
+                              securityGroups:
+                                description: The names of the security groups to assign
+                                  to the instance
+                                items:
+                                  properties:
+                                    description:
+                                      type: string
+                                    id:
+                                      type: string
+                                    name:
+                                      type: string
+                                    notTags:
+                                      type: string
+                                    notTagsAny:
+                                      type: string
+                                    projectId:
+                                      type: string
+                                    tags:
+                                      type: string
+                                    tagsAny:
+                                      type: string
+                                  type: object
+                                type: array
+                              serverGroupID:
+                                description: The server group to assign the machine
+                                  to
+                                type: string
+                              serverMetadata:
+                                additionalProperties:
+                                  type: string
+                                description: Metadata mapping. Allows you to create
+                                  a map of key value pairs to add to the server instance.
+                                type: object
+                              sshKeyName:
+                                description: The ssh key to inject in the instance
+                                type: string
+                              tags:
+                                description: |-
+                                  Machine tags
+                                  Requires Nova api 2.52 minimum!
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              trunk:
+                                description: Whether the server instance is created
+                                  on a trunk port or not.
+                                type: boolean
+                            type: object
+                        type: object
+                      cloudName:
+                        description: The name of the cloud to use from the clouds
+                          secret
+                        type: string
+                      controlPlaneAvailabilityZones:
+                        description: ControlPlaneAvailabilityZones is the az to deploy
+                          control plane to
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      controlPlaneOmitAvailabilityZone:
+                        description: |-
+                          Indicates whether to omit the az for control plane nodes, allowing the Nova scheduler
+                          to make a decision on which az to use based on other scheduling constraints
+                        type: boolean
+                      disableAPIServerFloatingIP:
+                        description: |-
+                          DisableAPIServerFloatingIP determines whether or not to attempt to attach a floating
+                          IP to the API server. This allows for the creation of clusters when attaching a floating
+                          IP to the API server (and hence, in many cases, exposing the API server to the internet)
+                          is not possible or desirable, e.g. if using a shared VLAN for communication between
+                          management and workload clusters or when the management cluster is inside the
+                          project network.
+                          This option requires that the API server use a VIP on the cluster network so that the
+                          underlying machines can change without changing ControlPlaneEndpoint.Host.
+                          When using a managed load balancer, this VIP will be managed automatically.
+                          If not using a managed load balancer, cluster configuration will fail without additional
+                          configuration to manage the VIP on the control plane machines, which falls outside of
+                          the scope of this controller.
+                        type: boolean
+                      disablePortSecurity:
+                        description: |-
+                          DisablePortSecurity disables the port security of the network created for the
+                          Kubernetes cluster, which also disables SecurityGroups
+                        type: boolean
+                      dnsNameservers:
+                        description: |-
+                          DNSNameservers is the list of nameservers for OpenStack Subnet being created.
+                          Set this value when you need create a new network/subnet while the access
+                          through DNS is required.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      externalNetworkId:
+                        description: |-
+                          ExternalNetworkID is the ID of an external OpenStack Network. This is necessary
+                          to get public internet to the VMs.
+                        type: string
+                      externalRouterIPs:
+                        description: |-
+                          ExternalRouterIPs is an array of externalIPs on the respective subnets.
+                          This is necessary if the router needs a fixed ip in a specific subnet.
+                        items:
+                          properties:
+                            fixedIP:
+                              description: The FixedIP in the corresponding subnet
+                              type: string
+                            subnet:
+                              description: The subnet in which the FixedIP is used
+                                for the Gateway of this router
+                              properties:
+                                cidr:
+                                  type: string
+                                description:
+                                  type: string
+                                gateway_ip:
+                                  type: string
+                                id:
+                                  type: string
+                                ipVersion:
+                                  type: integer
+                                ipv6AddressMode:
+                                  type: string
+                                ipv6RaMode:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  type: string
+                                notTagsAny:
+                                  type: string
+                                projectId:
+                                  type: string
+                                tags:
+                                  type: string
+                                tagsAny:
+                                  type: string
+                              type: object
+                          required:
+                          - subnet
+                          type: object
+                        type: array
+                      identityRef:
+                        description: IdentityRef is a reference to a identity to be
+                          used when reconciling this cluster
+                        properties:
+                          kind:
+                            description: |-
+                              Kind of the identity. Must be supported by the infrastructure
+                              provider and may be either cluster or namespace-scoped.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name of the infrastructure identity to be used.
+                              Must be either a cluster-scoped resource, or namespaced-scoped
+                              resource the same namespace as the resource(s) being provisioned.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      managedSecurityGroups:
+                        description: |-
+                          ManagedSecurityGroups determines whether OpenStack security groups for the cluster
+                          will be managed by the OpenStack provider or whether pre-existing security groups will
+                          be specified as part of the configuration.
+                          By default, the managed security groups have rules that allow the Kubelet, etcd, the
+                          Kubernetes API server and the Calico CNI plugin to function correctly.
+                        type: boolean
+                      network:
+                        description: If NodeCIDR cannot be set this can be used to
+                          detect an existing network.
+                        properties:
+                          description:
+                            type: string
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          notTags:
+                            type: string
+                          notTagsAny:
+                            type: string
+                          projectId:
+                            type: string
+                          tags:
+                            type: string
+                          tagsAny:
+                            type: string
+                        type: object
+                      networkMtu:
+                        description: |-
+                          NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
+                          This value will be used only if the Cluster actuator creates the network.
+                          If leaved empty, the network will have the default MTU defined in Openstack network service.
+                          To use this field, the Openstack installation requires the net-mtu neutron API extension.
+                        type: integer
+                      nodeCidr:
+                        description: |-
+                          NodeCIDR is the OpenStack Subnet to be created. Cluster actuator will create a
+                          network, a subnet with NodeCIDR, and a router connected to this subnet.
+                          If you leave this empty, no network will be created.
+                        type: string
+                      router:
+                        description: |-
+                          If NodeCIDR is set this option can be used to detect an existing router.
+                          If specified, no new router will be created.
+                        properties:
+                          description:
+                            type: string
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          notTags:
+                            type: string
+                          notTagsAny:
+                            type: string
+                          projectId:
+                            type: string
+                          tags:
+                            type: string
+                          tagsAny:
+                            type: string
+                        type: object
+                      subnet:
+                        description: If NodeCIDR cannot be set this can be used to
+                          detect an existing subnet.
+                        properties:
+                          cidr:
+                            type: string
+                          description:
+                            type: string
+                          gateway_ip:
+                            type: string
+                          id:
+                            type: string
+                          ipVersion:
+                            type: integer
+                          ipv6AddressMode:
+                            type: string
+                          ipv6RaMode:
+                            type: string
+                          name:
+                            type: string
+                          notTags:
+                            type: string
+                          notTagsAny:
+                            type: string
+                          projectId:
+                            type: string
+                          tags:
+                            type: string
+                          tagsAny:
+                            type: string
+                        type: object
+                      tags:
+                        description: Tags for all resources in cluster
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackClusterTemplate is the Schema for the openstackclustertemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackClusterTemplateSpec defines the desired state of
+              OpenStackClusterTemplate.
+            properties:
+              template:
+                description: OpenStackClusterTemplateResource describes the data needed
+                  to create a OpenStackCluster from a template.
+                properties:
+                  spec:
+                    description: OpenStackClusterSpec defines the desired state of
+                      OpenStackCluster.
+                    properties:
+                      apiServerFixedIP:
+                        description: |-
+                          APIServerFixedIP is the fixed IP which will be associated with the API server.
+                          In the case where the API server has a floating IP but not a managed load balancer,
+                          this field is not used.
+                          If a managed load balancer is used and this field is not specified, a fixed IP will
+                          be dynamically allocated for the load balancer.
+                          If a managed load balancer is not used AND the API server floating IP is disabled,
+                          this field MUST be specified and should correspond to a pre-allocated port that
+                          holds the fixed IP to be used as a VIP.
+                        type: string
+                      apiServerFloatingIP:
+                        description: |-
+                          APIServerFloatingIP is the floatingIP which will be associated with the API server.
+                          The floatingIP will be created if it does not already exist.
+                          If not specified, a new floatingIP is allocated.
+                          This field is not used if DisableAPIServerFloatingIP is set to true.
+                        type: string
+                      apiServerLoadBalancer:
+                        description: |-
+                          APIServerLoadBalancer configures the optional LoadBalancer for the APIServer.
+                          If not specified, no load balancer will be created for the API server.
+                        properties:
+                          additionalPorts:
+                            description: AdditionalPorts adds additional tcp ports
+                              to the load balancer.
+                            items:
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: set
+                          allowedCIDRs:
+                            description: AllowedCIDRs restrict access to all API-Server
+                              listeners to the given address CIDRs.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          availabilityZone:
+                            description: AvailabilityZone is the failure domain that
+                              will be used to create the APIServerLoadBalancer Spec.
+                            type: string
+                          enabled:
+                            default: true
+                            description: |-
+                              Enabled defines whether a load balancer should be created. This value
+                              defaults to true if an APIServerLoadBalancer is given.
+
+                              There is no reason to set this to false. To disable creation of the
+                              API server loadbalancer, omit the APIServerLoadBalancer field in the
+                              cluster spec instead.
+                            type: boolean
+                          flavor:
+                            description: Flavor is the flavor name that will be used
+                              to create the APIServerLoadBalancer Spec.
+                            type: string
+                          network:
+                            description: Network defines which network should the
+                              load balancer be allocated on.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              filter:
+                                description: Filter specifies a filter to select an
+                                  OpenStack network. If provided, cannot be empty.
+                                minProperties: 1
+                                properties:
+                                  description:
+                                    type: string
+                                  name:
+                                    type: string
+                                  notTags:
+                                    description: |-
+                                      NotTags is a list of tags to filter by. If specified, resources which
+                                      contain all of the given tags will be excluded from the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  notTagsAny:
+                                    description: |-
+                                      NotTagsAny is a list of tags to filter by. If specified, resources
+                                      which contain any of the given tags will be excluded from the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  projectID:
+                                    type: string
+                                  tags:
+                                    description: |-
+                                      Tags is a list of tags to filter by. If specified, the resource must
+                                      have all of the tags specified to be included in the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  tagsAny:
+                                    description: |-
+                                      TagsAny is a list of tags to filter by. If specified, the resource
+                                      must have at least one of the tags specified to be included in the
+                                      result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                type: object
+                              id:
+                                description: ID is the ID of the network to use. If
+                                  ID is provided, the other filters cannot be provided.
+                                  Must be in UUID format.
+                                format: uuid
+                                type: string
+                            type: object
+                          provider:
+                            description: |-
+                              Provider specifies name of a specific Octavia provider to use for the
+                              API load balancer. The Octavia default will be used if it is not
+                              specified.
+                            type: string
+                          subnets:
+                            description: |-
+                              Subnets define which subnets should the load balancer be allocated on.
+                              It is expected that subnets are located on the network specified in this resource.
+                              Only the first element is taken into account.
+                              kubebuilder:validation:MaxLength:=2
+                            items:
+                              description: SubnetParam specifies an OpenStack subnet
+                                to use. It may be specified by either ID or filter,
+                                but not both.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                filter:
+                                  description: Filter specifies a filter to select
+                                    the subnet. It must match exactly one subnet.
+                                  minProperties: 1
+                                  properties:
+                                    cidr:
+                                      type: string
+                                    description:
+                                      type: string
+                                    gatewayIP:
+                                      type: string
+                                    ipVersion:
+                                      type: integer
+                                    ipv6AddressMode:
+                                      type: string
+                                    ipv6RAMode:
+                                      type: string
+                                    name:
+                                      type: string
+                                    notTags:
+                                      description: |-
+                                        NotTags is a list of tags to filter by. If specified, resources which
+                                        contain all of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    notTagsAny:
+                                      description: |-
+                                        NotTagsAny is a list of tags to filter by. If specified, resources
+                                        which contain any of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    projectID:
+                                      type: string
+                                    tags:
+                                      description: |-
+                                        Tags is a list of tags to filter by. If specified, the resource must
+                                        have all of the tags specified to be included in the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    tagsAny:
+                                      description: |-
+                                        TagsAny is a list of tags to filter by. If specified, the resource
+                                        must have at least one of the tags specified to be included in the
+                                        result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  type: object
+                                id:
+                                  description: ID is the uuid of the subnet. It will
+                                    not be validated.
+                                  format: uuid
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - enabled
+                        type: object
+                      apiServerPort:
+                        description: |-
+                          APIServerPort is the port on which the listener on the APIServer
+                          will be created. If specified, it must be an integer between 0 and 65535.
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                      bastion:
+                        description: |-
+                          Bastion is the OpenStack instance to login the nodes
+
+                          As a rolling update is not ideal during a bastion host session, we
+                          prevent changes to a running bastion configuration. To make changes, it's required
+                          to first set `enabled: false` which will remove the bastion and then changes can be made.
+                        properties:
+                          availabilityZone:
+                            description: AvailabilityZone is the failure domain that
+                              will be used to create the Bastion Spec.
+                            type: string
+                          enabled:
+                            default: true
+                            description: |-
+                              Enabled means that bastion is enabled. The bastion is enabled by
+                              default if this field is not specified. Set this field to false to disable the
+                              bastion.
+
+                              It is not currently possible to remove the bastion from the cluster
+                              spec without first disabling it by setting this field to false and
+                              waiting until the bastion has been deleted.
+                            type: boolean
+                          floatingIP:
+                            description: |-
+                              FloatingIP which will be associated to the bastion machine. It's the IP address, not UUID.
+                              The floating IP should already exist and should not be associated with a port. If FIP of this address does not
+                              exist, CAPO will try to create it, but by default only OpenStack administrators have privileges to do so.
+                            format: ipv4
+                            type: string
+                          spec:
+                            description: Spec for the bastion itself
+                            properties:
+                              additionalBlockDevices:
+                                description: AdditionalBlockDevices is a list of specifications
+                                  for additional block devices to attach to the server
+                                  instance
+                                items:
+                                  description: AdditionalBlockDevice is a block device
+                                    to attach to the server.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the block device in the context of a machine.
+                                        If the block device is a volume, the Cinder volume will be named
+                                        as a combination of the machine name and this name.
+                                        Also, this name will be used for tagging the block device.
+                                        Information about the block device tag can be obtained from the OpenStack
+                                        metadata API or the config drive.
+                                        Name cannot be 'root', which is reserved for the root volume.
+                                      type: string
+                                    sizeGiB:
+                                      description: SizeGiB is the size of the block
+                                        device in gibibytes (GiB).
+                                      minimum: 1
+                                      type: integer
+                                    storage:
+                                      description: |-
+                                        Storage specifies the storage type of the block device and
+                                        additional storage options.
+                                      properties:
+                                        type:
+                                          description: |-
+                                            Type is the type of block device to create.
+                                            This can be either "Volume" or "Local".
+                                          type: string
+                                        volume:
+                                          description: Volume contains additional
+                                            storage options for a volume block device.
+                                          properties:
+                                            availabilityZone:
+                                              description: |-
+                                                AvailabilityZone is the volume availability zone to create the volume
+                                                in. If not specified, the volume will be created without an explicit
+                                                availability zone.
+                                              properties:
+                                                from:
+                                                  default: Name
+                                                  description: |-
+                                                    From specifies where we will obtain the availability zone for the
+                                                    volume. The options are "Name" and "Machine". If "Name" is specified
+                                                    then the Name field must also be specified. If "Machine" is specified
+                                                    the volume will use the value of FailureDomain, if any, from the
+                                                    associated Machine.
+                                                  enum:
+                                                  - Name
+                                                  - Machine
+                                                  type: string
+                                                name:
+                                                  description: |-
+                                                    Name is the name of a volume availability zone to use. It is required
+                                                    if From is "Name". The volume availability zone name may not contain
+                                                    spaces.
+                                                  minLength: 1
+                                                  pattern: ^[^ ]+$
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: name is required when from
+                                                  is 'Name' or default
+                                                rule: '!has(self.from) || self.from
+                                                  == ''Name'' ? has(self.name) : !has(self.name)'
+                                            type:
+                                              description: |-
+                                                Type is the Cinder volume type of the volume.
+                                                If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                                will be used.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - sizeGiB
+                                  - storage
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              configDrive:
+                                description: Config Drive support
+                                type: boolean
+                              flavor:
+                                description: The flavor reference for the flavor for
+                                  your server instance.
+                                minLength: 1
+                                type: string
+                              flavorID:
+                                description: |-
+                                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                                  over Flavor.
+                                minLength: 1
+                                type: string
+                              floatingIPPoolRef:
+                                description: |-
+                                  floatingIPPoolRef is a reference to a IPPool that will be assigned
+                                  to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
+                                  will be assigned to the OpenStackMachine.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              identityRef:
+                                description: |-
+                                  IdentityRef is a reference to a secret holding OpenStack credentials
+                                  to be used when reconciling this machine. If not specified, the
+                                  credentials specified in the cluster will be used.
+                                properties:
+                                  cloudName:
+                                    description: CloudName specifies the name of the
+                                      entry in the clouds.yaml file to use.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of a secret in the same namespace as the resource being provisioned.
+                                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                                    type: string
+                                  region:
+                                    description: |-
+                                      Region specifies an OpenStack region to use. If specified, it overrides
+                                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                                      value will be included in providerID.
+                                    type: string
+                                required:
+                                - cloudName
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: region is immutable
+                                  rule: (!has(self.region) && !has(oldSelf.region))
+                                    || self.region == oldSelf.region
+                              image:
+                                description: |-
+                                  The image to use for your server instance.
+                                  If the rootVolume is specified, this will be used when creating the root volume.
+                                maxProperties: 1
+                                minProperties: 1
+                                properties:
+                                  filter:
+                                    description: |-
+                                      Filter describes a query for an image. If specified, the combination
+                                      of name and tags must return a single matching image or an error will
+                                      be raised.
+                                    minProperties: 1
+                                    properties:
+                                      name:
+                                        description: The name of the desired image.
+                                          If specified, the combination of name and
+                                          tags must return a single matching image
+                                          or an error will be raised.
+                                        type: string
+                                      tags:
+                                        description: The tags associated with the
+                                          desired image. If specified, the combination
+                                          of name and tags must return a single matching
+                                          image or an error will be raised.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  id:
+                                    description: ID is the uuid of the image. ID will
+                                      not be validated before use.
+                                    format: uuid
+                                    type: string
+                                  imageRef:
+                                    description: |-
+                                      ImageRef is a reference to an ORC Image in the same namespace as the
+                                      referring object.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the referenced
+                                          resource
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                              ports:
+                                description: |-
+                                  Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                                  If not specified a default port will be added for the default cluster network.
+                                items:
+                                  properties:
+                                    adminStateUp:
+                                      description: AdminStateUp specifies whether
+                                        the port should be created in the up (true)
+                                        or down (false) state. The default is up.
+                                      type: boolean
+                                    allowedAddressPairs:
+                                      description: |-
+                                        AllowedAddressPairs is a list of address pairs which Neutron will
+                                        allow the port to send traffic from in addition to the port's
+                                        addresses. If not specified, the MAC Address will be the MAC Address
+                                        of the port. Depending on the configuration of Neutron, it may be
+                                        supported to specify a CIDR instead of a specific IP address.
+                                      items:
+                                        properties:
+                                          ipAddress:
+                                            description: |-
+                                              IPAddress is the IP address of the allowed address pair. Depending on
+                                              the configuration of Neutron, it may be supported to specify a CIDR
+                                              instead of a specific IP address.
+                                            type: string
+                                          macAddress:
+                                            description: |-
+                                              MACAddress is the MAC address of the allowed address pair. If not
+                                              specified, the MAC address will be the MAC address of the port.
+                                            type: string
+                                        required:
+                                        - ipAddress
+                                        type: object
+                                      type: array
+                                    description:
+                                      description: Description is a human-readable
+                                        description for the port.
+                                      type: string
+                                    disablePortSecurity:
+                                      description: |-
+                                        DisablePortSecurity enables or disables the port security when set.
+                                        When not set, it takes the value of the corresponding field at the network level.
+                                      type: boolean
+                                    fixedIPs:
+                                      description: FixedIPs is a list of pairs of
+                                        subnet and/or IP address to assign to the
+                                        port. If specified, these must be subnets
+                                        of the port's network.
+                                      items:
+                                        properties:
+                                          ipAddress:
+                                            description: |-
+                                              IPAddress is a specific IP address to assign to the port. If Subnet
+                                              is also specified, IPAddress must be a valid IP address in the
+                                              subnet. If Subnet is not specified, IPAddress must be a valid IP
+                                              address in any subnet of the port's network.
+                                            type: string
+                                          subnet:
+                                            description: |-
+                                              Subnet is an openstack subnet query that will return the id of a subnet to create
+                                              the fixed IP of a port in. This query must not return more than one subnet.
+                                            maxProperties: 1
+                                            minProperties: 1
+                                            properties:
+                                              filter:
+                                                description: Filter specifies a filter
+                                                  to select the subnet. It must match
+                                                  exactly one subnet.
+                                                minProperties: 1
+                                                properties:
+                                                  cidr:
+                                                    type: string
+                                                  description:
+                                                    type: string
+                                                  gatewayIP:
+                                                    type: string
+                                                  ipVersion:
+                                                    type: integer
+                                                  ipv6AddressMode:
+                                                    type: string
+                                                  ipv6RAMode:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  notTags:
+                                                    description: |-
+                                                      NotTags is a list of tags to filter by. If specified, resources which
+                                                      contain all of the given tags will be excluded from the result.
+                                                    items:
+                                                      description: |-
+                                                        NeutronTag represents a tag on a Neutron resource.
+                                                        It may not be empty and may not contain commas.
+                                                      minLength: 1
+                                                      pattern: ^[^,]+$
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                  notTagsAny:
+                                                    description: |-
+                                                      NotTagsAny is a list of tags to filter by. If specified, resources
+                                                      which contain any of the given tags will be excluded from the result.
+                                                    items:
+                                                      description: |-
+                                                        NeutronTag represents a tag on a Neutron resource.
+                                                        It may not be empty and may not contain commas.
+                                                      minLength: 1
+                                                      pattern: ^[^,]+$
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                  projectID:
+                                                    type: string
+                                                  tags:
+                                                    description: |-
+                                                      Tags is a list of tags to filter by. If specified, the resource must
+                                                      have all of the tags specified to be included in the result.
+                                                    items:
+                                                      description: |-
+                                                        NeutronTag represents a tag on a Neutron resource.
+                                                        It may not be empty and may not contain commas.
+                                                      minLength: 1
+                                                      pattern: ^[^,]+$
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                  tagsAny:
+                                                    description: |-
+                                                      TagsAny is a list of tags to filter by. If specified, the resource
+                                                      must have at least one of the tags specified to be included in the
+                                                      result.
+                                                    items:
+                                                      description: |-
+                                                        NeutronTag represents a tag on a Neutron resource.
+                                                        It may not be empty and may not contain commas.
+                                                      minLength: 1
+                                                      pattern: ^[^,]+$
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                type: object
+                                              id:
+                                                description: ID is the uuid of the
+                                                  subnet. It will not be validated.
+                                                format: uuid
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    hostID:
+                                      description: HostID specifies the ID of the
+                                        host where the port resides.
+                                      type: string
+                                    macAddress:
+                                      description: MACAddress specifies the MAC address
+                                        of the port. If not specified, the MAC address
+                                        will be generated.
+                                      type: string
+                                    nameSuffix:
+                                      description: NameSuffix will be appended to
+                                        the name of the port if specified. If unspecified,
+                                        instead the 0-based index of the port in the
+                                        list is used.
+                                      type: string
+                                    network:
+                                      description: |-
+                                        Network is a query for an openstack network that the port will be created or discovered on.
+                                        This will fail if the query returns more than one network.
+                                      maxProperties: 1
+                                      minProperties: 1
+                                      properties:
+                                        filter:
+                                          description: Filter specifies a filter to
+                                            select an OpenStack network. If provided,
+                                            cannot be empty.
+                                          minProperties: 1
+                                          properties:
+                                            description:
+                                              type: string
+                                            name:
+                                              type: string
+                                            notTags:
+                                              description: |-
+                                                NotTags is a list of tags to filter by. If specified, resources which
+                                                contain all of the given tags will be excluded from the result.
+                                              items:
+                                                description: |-
+                                                  NeutronTag represents a tag on a Neutron resource.
+                                                  It may not be empty and may not contain commas.
+                                                minLength: 1
+                                                pattern: ^[^,]+$
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                            notTagsAny:
+                                              description: |-
+                                                NotTagsAny is a list of tags to filter by. If specified, resources
+                                                which contain any of the given tags will be excluded from the result.
+                                              items:
+                                                description: |-
+                                                  NeutronTag represents a tag on a Neutron resource.
+                                                  It may not be empty and may not contain commas.
+                                                minLength: 1
+                                                pattern: ^[^,]+$
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                            projectID:
+                                              type: string
+                                            tags:
+                                              description: |-
+                                                Tags is a list of tags to filter by. If specified, the resource must
+                                                have all of the tags specified to be included in the result.
+                                              items:
+                                                description: |-
+                                                  NeutronTag represents a tag on a Neutron resource.
+                                                  It may not be empty and may not contain commas.
+                                                minLength: 1
+                                                pattern: ^[^,]+$
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                            tagsAny:
+                                              description: |-
+                                                TagsAny is a list of tags to filter by. If specified, the resource
+                                                must have at least one of the tags specified to be included in the
+                                                result.
+                                              items:
+                                                description: |-
+                                                  NeutronTag represents a tag on a Neutron resource.
+                                                  It may not be empty and may not contain commas.
+                                                minLength: 1
+                                                pattern: ^[^,]+$
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          type: object
+                                        id:
+                                          description: ID is the ID of the network
+                                            to use. If ID is provided, the other filters
+                                            cannot be provided. Must be in UUID format.
+                                          format: uuid
+                                          type: string
+                                      type: object
+                                    profile:
+                                      description: |-
+                                        Profile is a set of key-value pairs that are used for binding
+                                        details. We intentionally don't expose this as a map[string]string
+                                        because we only want to enable the users to set the values of the
+                                        keys that are known to work in OpenStack Networking API.  See
+                                        https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                                        To set profiles, your tenant needs permissions rule:create_port, and
+                                        rule:create_port:binding:profile
+                                      properties:
+                                        ovsHWOffload:
+                                          description: |-
+                                            OVSHWOffload enables or disables the OVS hardware offload feature.
+                                            This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                                            See: https://bugs.launchpad.net/nova/+bug/2020813
+                                          type: boolean
+                                        trustedVF:
+                                          description: TrustedVF enables or disables
+                                            the “trusted mode” for the VF.
+                                          type: boolean
+                                      type: object
+                                    propagateUplinkStatus:
+                                      description: PropageteUplinkStatus enables or
+                                        disables the propagate uplink status on the
+                                        port.
+                                      type: boolean
+                                    securityGroups:
+                                      description: SecurityGroups is a list of the
+                                        names, uuids, filters or any combination these
+                                        of the security groups to assign to the instance.
+                                      items:
+                                        description: SecurityGroupParam specifies
+                                          an OpenStack security group. It may be specified
+                                          by ID or filter, but not both.
+                                        maxProperties: 1
+                                        minProperties: 1
+                                        properties:
+                                          filter:
+                                            description: Filter specifies a query
+                                              to select an OpenStack security group.
+                                              If provided, cannot be empty.
+                                            minProperties: 1
+                                            properties:
+                                              description:
+                                                type: string
+                                              name:
+                                                type: string
+                                              notTags:
+                                                description: |-
+                                                  NotTags is a list of tags to filter by. If specified, resources which
+                                                  contain all of the given tags will be excluded from the result.
+                                                items:
+                                                  description: |-
+                                                    NeutronTag represents a tag on a Neutron resource.
+                                                    It may not be empty and may not contain commas.
+                                                  minLength: 1
+                                                  pattern: ^[^,]+$
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                              notTagsAny:
+                                                description: |-
+                                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                                  which contain any of the given tags will be excluded from the result.
+                                                items:
+                                                  description: |-
+                                                    NeutronTag represents a tag on a Neutron resource.
+                                                    It may not be empty and may not contain commas.
+                                                  minLength: 1
+                                                  pattern: ^[^,]+$
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                              projectID:
+                                                type: string
+                                              tags:
+                                                description: |-
+                                                  Tags is a list of tags to filter by. If specified, the resource must
+                                                  have all of the tags specified to be included in the result.
+                                                items:
+                                                  description: |-
+                                                    NeutronTag represents a tag on a Neutron resource.
+                                                    It may not be empty and may not contain commas.
+                                                  minLength: 1
+                                                  pattern: ^[^,]+$
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                              tagsAny:
+                                                description: |-
+                                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                                  must have at least one of the tags specified to be included in the
+                                                  result.
+                                                items:
+                                                  description: |-
+                                                    NeutronTag represents a tag on a Neutron resource.
+                                                    It may not be empty and may not contain commas.
+                                                  minLength: 1
+                                                  pattern: ^[^,]+$
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            type: object
+                                          id:
+                                            description: ID is the ID of the security
+                                              group to use. If ID is provided, the
+                                              other filters cannot be provided. Must
+                                              be in UUID format.
+                                            format: uuid
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    tags:
+                                      description: |-
+                                        Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                                        These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    trunk:
+                                      description: |-
+                                        Trunk specifies whether trunking is enabled at the port level. If not
+                                        provided the value is inherited from the machine, or false for a
+                                        bastion host.
+                                      type: boolean
+                                    valueSpecs:
+                                      description: |-
+                                        Value specs are extra parameters to include in the API request with OpenStack.
+                                        This is an extension point for the API, so what they do and if they are supported,
+                                        depends on the specific OpenStack implementation.
+                                      items:
+                                        description: ValueSpec represents a single
+                                          value_spec key-value pair.
+                                        properties:
+                                          key:
+                                            description: Key is the key in the key-value
+                                              pair.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              Name is the name of the key-value pair.
+                                              This is just for identifying the pair and will not be sent to the OpenStack API.
+                                            type: string
+                                          value:
+                                            description: Value is the value in the
+                                              key-value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    vnicType:
+                                      description: |-
+                                        VNICType specifies the type of vNIC which this port should be
+                                        attached to. This is used to determine which mechanism driver(s) to
+                                        be used to bind the port. The valid values are normal, macvtap,
+                                        direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                                        remote-managed, although these values will not be validated in this
+                                        API to ensure compatibility with future neutron changes or custom
+                                        implementations. What type of vNIC is actually available depends on
+                                        deployments. If not specified, the Neutron default value is used.
+                                      type: string
+                                  type: object
+                                type: array
+                              providerID:
+                                description: ProviderID is the unique identifier as
+                                  specified by the cloud provider.
+                                type: string
+                              rootVolume:
+                                description: The volume metadata to boot from
+                                properties:
+                                  availabilityZone:
+                                    description: |-
+                                      AvailabilityZone is the volume availability zone to create the volume
+                                      in. If not specified, the volume will be created without an explicit
+                                      availability zone.
+                                    properties:
+                                      from:
+                                        default: Name
+                                        description: |-
+                                          From specifies where we will obtain the availability zone for the
+                                          volume. The options are "Name" and "Machine". If "Name" is specified
+                                          then the Name field must also be specified. If "Machine" is specified
+                                          the volume will use the value of FailureDomain, if any, from the
+                                          associated Machine.
+                                        enum:
+                                        - Name
+                                        - Machine
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of a volume availability zone to use. It is required
+                                          if From is "Name". The volume availability zone name may not contain
+                                          spaces.
+                                        minLength: 1
+                                        pattern: ^[^ ]+$
+                                        type: string
+                                    type: object
+                                    x-kubernetes-validations:
+                                    - message: name is required when from is 'Name'
+                                        or default
+                                      rule: '!has(self.from) || self.from == ''Name''
+                                        ? has(self.name) : !has(self.name)'
+                                  sizeGiB:
+                                    description: SizeGiB is the size of the block
+                                      device in gibibytes (GiB).
+                                    minimum: 1
+                                    type: integer
+                                  type:
+                                    description: |-
+                                      Type is the Cinder volume type of the volume.
+                                      If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                      will be used.
+                                    type: string
+                                required:
+                                - sizeGiB
+                                type: object
+                              schedulerHintAdditionalProperties:
+                                description: |-
+                                  SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints
+                                  to the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,
+                                  such as specifying certain host aggregates or availability zones.
+                                items:
+                                  description: |-
+                                    SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.
+                                    It includes a Name to identify the property and a Value that can be of various types.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the scheduler hint property.
+                                        It is a unique identifier for the property.
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value is the value of the scheduler hint property, which can be of various types
+                                        (e.g., bool, string, int). The type is indicated by the Value.Type field.
+                                      properties:
+                                        bool:
+                                          description: |-
+                                            Bool is the boolean value of the scheduler hint, used when Type is "Bool".
+                                            This field is required if type is 'Bool', and must not be set otherwise.
+                                          type: boolean
+                                        number:
+                                          description: |-
+                                            Number is the integer value of the scheduler hint, used when Type is "Number".
+                                            This field is required if type is 'Number', and must not be set otherwise.
+                                          type: integer
+                                        string:
+                                          description: |-
+                                            String is the string value of the scheduler hint, used when Type is "String".
+                                            This field is required if type is 'String', and must not be set otherwise.
+                                          maxLength: 255
+                                          minLength: 1
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type represents the type of the value.
+                                            Valid values are Bool, String, and Number.
+                                          enum:
+                                          - Bool
+                                          - String
+                                          - Number
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: bool is required when type is Bool,
+                                          and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''Bool''
+                                          ? has(self.bool) : !has(self.bool)'
+                                      - message: number is required when type is Number,
+                                          and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''Number''
+                                          ? has(self.number) : !has(self.number)'
+                                      - message: string is required when type is String,
+                                          and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''String''
+                                          ? has(self.string) : !has(self.string)'
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              securityGroups:
+                                description: The names of the security groups to assign
+                                  to the instance
+                                items:
+                                  description: SecurityGroupParam specifies an OpenStack
+                                    security group. It may be specified by ID or filter,
+                                    but not both.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    filter:
+                                      description: Filter specifies a query to select
+                                        an OpenStack security group. If provided,
+                                        cannot be empty.
+                                      minProperties: 1
+                                      properties:
+                                        description:
+                                          type: string
+                                        name:
+                                          type: string
+                                        notTags:
+                                          description: |-
+                                            NotTags is a list of tags to filter by. If specified, resources which
+                                            contain all of the given tags will be excluded from the result.
+                                          items:
+                                            description: |-
+                                              NeutronTag represents a tag on a Neutron resource.
+                                              It may not be empty and may not contain commas.
+                                            minLength: 1
+                                            pattern: ^[^,]+$
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        notTagsAny:
+                                          description: |-
+                                            NotTagsAny is a list of tags to filter by. If specified, resources
+                                            which contain any of the given tags will be excluded from the result.
+                                          items:
+                                            description: |-
+                                              NeutronTag represents a tag on a Neutron resource.
+                                              It may not be empty and may not contain commas.
+                                            minLength: 1
+                                            pattern: ^[^,]+$
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        projectID:
+                                          type: string
+                                        tags:
+                                          description: |-
+                                            Tags is a list of tags to filter by. If specified, the resource must
+                                            have all of the tags specified to be included in the result.
+                                          items:
+                                            description: |-
+                                              NeutronTag represents a tag on a Neutron resource.
+                                              It may not be empty and may not contain commas.
+                                            minLength: 1
+                                            pattern: ^[^,]+$
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        tagsAny:
+                                          description: |-
+                                            TagsAny is a list of tags to filter by. If specified, the resource
+                                            must have at least one of the tags specified to be included in the
+                                            result.
+                                          items:
+                                            description: |-
+                                              NeutronTag represents a tag on a Neutron resource.
+                                              It may not be empty and may not contain commas.
+                                            minLength: 1
+                                            pattern: ^[^,]+$
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                      type: object
+                                    id:
+                                      description: ID is the ID of the security group
+                                        to use. If ID is provided, the other filters
+                                        cannot be provided. Must be in UUID format.
+                                      format: uuid
+                                      type: string
+                                  type: object
+                                type: array
+                              serverGroup:
+                                description: The server group to assign the machine
+                                  to.
+                                maxProperties: 1
+                                minProperties: 1
+                                properties:
+                                  filter:
+                                    description: Filter specifies a query to select
+                                      an OpenStack server group. If provided, it cannot
+                                      be empty.
+                                    minProperties: 1
+                                    properties:
+                                      name:
+                                        description: Name is the name of a server
+                                          group to look for.
+                                        type: string
+                                    type: object
+                                  id:
+                                    description: ID is the ID of the server group
+                                      to use.
+                                    format: uuid
+                                    type: string
+                                type: object
+                              serverMetadata:
+                                description: Metadata mapping. Allows you to create
+                                  a map of key value pairs to add to the server instance.
+                                items:
+                                  properties:
+                                    key:
+                                      description: Key is the server metadata key
+                                      maxLength: 255
+                                      type: string
+                                    value:
+                                      description: Value is the server metadata value
+                                      maxLength: 255
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              sshKeyName:
+                                description: The ssh key to inject in the instance
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags which will be added to the machine and all dependent resources
+                                  which support them. These are in addition to Tags defined on the
+                                  cluster.
+                                  Requires Nova api 2.52 minimum!
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              trunk:
+                                description: Whether the server instance is created
+                                  on a trunk port or not.
+                                type: boolean
+                            required:
+                            - image
+                            type: object
+                            x-kubernetes-validations:
+                            - message: at least one of flavor or flavorID must be
+                                set
+                              rule: (has(self.flavor) || has(self.flavorID))
+                        type: object
+                        x-kubernetes-validations:
+                        - message: spec is required if bastion is enabled
+                          rule: '!self.enabled || has(self.spec)'
+                      controlPlaneAvailabilityZones:
+                        description: |-
+                          ControlPlaneAvailabilityZones is the set of availability zones which
+                          control plane machines may be deployed to.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                          It is normally populated automatically by the OpenStackCluster
+                          controller during cluster provisioning. If it is set on creation the
+                          control plane endpoint will use the values set here in preference to
+                          values set elsewhere.
+                          ControlPlaneEndpoint cannot be modified after ControlPlaneEndpoint.Host has been set.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      controlPlaneOmitAvailabilityZone:
+                        description: |-
+                          ControlPlaneOmitAvailabilityZone causes availability zone to be
+                          omitted when creating control plane nodes, allowing the Nova
+                          scheduler to make a decision on which availability zone to use based
+                          on other scheduling constraints
+                        type: boolean
+                      disableAPIServerFloatingIP:
+                        description: |-
+                          DisableAPIServerFloatingIP determines whether or not to attempt to attach a floating
+                          IP to the API server. This allows for the creation of clusters when attaching a floating
+                          IP to the API server (and hence, in many cases, exposing the API server to the internet)
+                          is not possible or desirable, e.g. if using a shared VLAN for communication between
+                          management and workload clusters or when the management cluster is inside the
+                          project network.
+                          This option requires that the API server use a VIP on the cluster network so that the
+                          underlying machines can change without changing ControlPlaneEndpoint.Host.
+                          When using a managed load balancer, this VIP will be managed automatically.
+                          If not using a managed load balancer, cluster configuration will fail without additional
+                          configuration to manage the VIP on the control plane machines, which falls outside of
+                          the scope of this controller.
+                        type: boolean
+                      disableExternalNetwork:
+                        description: |-
+                          DisableExternalNetwork specifies whether or not to attempt to connect the cluster
+                          to an external network. This allows for the creation of clusters when connecting
+                          to an external network is not possible or desirable, e.g. if using a provider network.
+                        type: boolean
+                      disablePortSecurity:
+                        description: |-
+                          DisablePortSecurity disables the port security of the network created for the
+                          Kubernetes cluster, which also disables SecurityGroups
+                        type: boolean
+                      externalNetwork:
+                        description: |-
+                          ExternalNetwork is the OpenStack Network to be used to get public internet to the VMs.
+                          This option is ignored if DisableExternalNetwork is set to true.
+
+                          If ExternalNetwork is defined it must refer to exactly one external network.
+
+                          If ExternalNetwork is not defined or is empty the controller will use any
+                          existing external network as long as there is only one. It is an
+                          error if ExternalNetwork is not defined and there are multiple
+                          external networks unless DisableExternalNetwork is also set.
+
+                          If ExternalNetwork is not defined and there are no external networks
+                          the controller will proceed as though DisableExternalNetwork was set.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a filter to select an OpenStack
+                              network. If provided, cannot be empty.
+                            minProperties: 1
+                            properties:
+                              description:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                description: |-
+                                  NotTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the ID of the network to use. If ID
+                              is provided, the other filters cannot be provided. Must
+                              be in UUID format.
+                            format: uuid
+                            type: string
+                        type: object
+                      externalRouterIPs:
+                        description: |-
+                          ExternalRouterIPs is an array of externalIPs on the respective subnets.
+                          This is necessary if the router needs a fixed ip in a specific subnet.
+                        items:
+                          properties:
+                            fixedIP:
+                              description: The FixedIP in the corresponding subnet
+                              type: string
+                            subnet:
+                              description: The subnet in which the FixedIP is used
+                                for the Gateway of this router
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                filter:
+                                  description: Filter specifies a filter to select
+                                    the subnet. It must match exactly one subnet.
+                                  minProperties: 1
+                                  properties:
+                                    cidr:
+                                      type: string
+                                    description:
+                                      type: string
+                                    gatewayIP:
+                                      type: string
+                                    ipVersion:
+                                      type: integer
+                                    ipv6AddressMode:
+                                      type: string
+                                    ipv6RAMode:
+                                      type: string
+                                    name:
+                                      type: string
+                                    notTags:
+                                      description: |-
+                                        NotTags is a list of tags to filter by. If specified, resources which
+                                        contain all of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    notTagsAny:
+                                      description: |-
+                                        NotTagsAny is a list of tags to filter by. If specified, resources
+                                        which contain any of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    projectID:
+                                      type: string
+                                    tags:
+                                      description: |-
+                                        Tags is a list of tags to filter by. If specified, the resource must
+                                        have all of the tags specified to be included in the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    tagsAny:
+                                      description: |-
+                                        TagsAny is a list of tags to filter by. If specified, the resource
+                                        must have at least one of the tags specified to be included in the
+                                        result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  type: object
+                                id:
+                                  description: ID is the uuid of the subnet. It will
+                                    not be validated.
+                                  format: uuid
+                                  type: string
+                              type: object
+                          required:
+                          - subnet
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      identityRef:
+                        description: |-
+                          IdentityRef is a reference to a secret holding OpenStack credentials
+                          to be used when reconciling this cluster. It is also to reconcile
+                          machines unless overridden in the machine spec.
+                        properties:
+                          cloudName:
+                            description: CloudName specifies the name of the entry
+                              in the clouds.yaml file to use.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of a secret in the same namespace as the resource being provisioned.
+                              The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                              The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                            type: string
+                          region:
+                            description: |-
+                              Region specifies an OpenStack region to use. If specified, it overrides
+                              any value in clouds.yaml. If specified for an OpenStackMachine, its
+                              value will be included in providerID.
+                            type: string
+                        required:
+                        - cloudName
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                            == oldSelf.region
+                      managedSecurityGroups:
+                        description: |-
+                          ManagedSecurityGroups determines whether OpenStack security groups for the cluster
+                          will be managed by the OpenStack provider or whether pre-existing security groups will
+                          be specified as part of the configuration.
+                          By default, the managed security groups have rules that allow the Kubelet, etcd, and the
+                          Kubernetes API server to function correctly.
+                          It's possible to add additional rules to the managed security groups.
+                          When defined to an empty struct, the managed security groups will be created with the default rules.
+                        properties:
+                          allNodesSecurityGroupRules:
+                            description: allNodesSecurityGroupRules defines the rules
+                              that should be applied to all nodes.
+                            items:
+                              description: |-
+                                SecurityGroupRuleSpec represent the basic information of the associated OpenStack
+                                Security Group Role.
+                                For now this is only used for the allNodesSecurityGroupRules but when we add
+                                other security groups, we'll need to add a validation because
+                                Remote* fields are mutually exclusive.
+                              properties:
+                                description:
+                                  description: description of the security group rule.
+                                  type: string
+                                direction:
+                                  description: |-
+                                    direction in which the security group rule is applied. The only values
+                                    allowed are "ingress" or "egress". For a compute instance, an ingress
+                                    security group rule is applied to incoming (ingress) traffic for that
+                                    instance. An egress rule is applied to traffic leaving the instance.
+                                  type: string
+                                etherType:
+                                  description: |-
+                                    etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the
+                                    ingress or egress rules.
+                                  type: string
+                                name:
+                                  description: |-
+                                    name of the security group rule.
+                                    It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
+                                  type: string
+                                portRangeMax:
+                                  description: |-
+                                    portRangeMax is a number in the range that is matched by the security group
+                                    rule. The portRangeMin attribute constrains the portRangeMax attribute.
+                                  type: integer
+                                portRangeMin:
+                                  description: |-
+                                    portRangeMin is a number in the range that is matched by the security group
+                                    rule. If the protocol is TCP or UDP, this value must be less than or equal
+                                    to the value of the portRangeMax attribute.
+                                  type: integer
+                                protocol:
+                                  description: protocol is the protocol that is matched
+                                    by the security group rule.
+                                  type: string
+                                remoteGroupID:
+                                  description: |-
+                                    remoteGroupID is the remote group ID to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  type: string
+                                remoteIPPrefix:
+                                  description: |-
+                                    remoteIPPrefix is the remote IP prefix to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  type: string
+                                remoteManagedGroups:
+                                  description: |-
+                                    remoteManagedGroups is the remote managed groups to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  items:
+                                    enum:
+                                    - bastion
+                                    - controlplane
+                                    - worker
+                                    type: string
+                                  type: array
+                              required:
+                              - direction
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          allowAllInClusterTraffic:
+                            default: false
+                            description: AllowAllInClusterTraffic allows all ingress
+                              and egress traffic between cluster nodes when set to
+                              true.
+                            type: boolean
+                          controlPlaneNodesSecurityGroupRules:
+                            description: controlPlaneNodesSecurityGroupRules defines
+                              the rules that should be applied to control plane nodes.
+                            items:
+                              description: |-
+                                SecurityGroupRuleSpec represent the basic information of the associated OpenStack
+                                Security Group Role.
+                                For now this is only used for the allNodesSecurityGroupRules but when we add
+                                other security groups, we'll need to add a validation because
+                                Remote* fields are mutually exclusive.
+                              properties:
+                                description:
+                                  description: description of the security group rule.
+                                  type: string
+                                direction:
+                                  description: |-
+                                    direction in which the security group rule is applied. The only values
+                                    allowed are "ingress" or "egress". For a compute instance, an ingress
+                                    security group rule is applied to incoming (ingress) traffic for that
+                                    instance. An egress rule is applied to traffic leaving the instance.
+                                  type: string
+                                etherType:
+                                  description: |-
+                                    etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the
+                                    ingress or egress rules.
+                                  type: string
+                                name:
+                                  description: |-
+                                    name of the security group rule.
+                                    It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
+                                  type: string
+                                portRangeMax:
+                                  description: |-
+                                    portRangeMax is a number in the range that is matched by the security group
+                                    rule. The portRangeMin attribute constrains the portRangeMax attribute.
+                                  type: integer
+                                portRangeMin:
+                                  description: |-
+                                    portRangeMin is a number in the range that is matched by the security group
+                                    rule. If the protocol is TCP or UDP, this value must be less than or equal
+                                    to the value of the portRangeMax attribute.
+                                  type: integer
+                                protocol:
+                                  description: protocol is the protocol that is matched
+                                    by the security group rule.
+                                  type: string
+                                remoteGroupID:
+                                  description: |-
+                                    remoteGroupID is the remote group ID to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  type: string
+                                remoteIPPrefix:
+                                  description: |-
+                                    remoteIPPrefix is the remote IP prefix to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  type: string
+                                remoteManagedGroups:
+                                  description: |-
+                                    remoteManagedGroups is the remote managed groups to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  items:
+                                    enum:
+                                    - bastion
+                                    - controlplane
+                                    - worker
+                                    type: string
+                                  type: array
+                              required:
+                              - direction
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          workerNodesSecurityGroupRules:
+                            description: workerNodesSecurityGroupRules defines the
+                              rules that should be applied to worker nodes.
+                            items:
+                              description: |-
+                                SecurityGroupRuleSpec represent the basic information of the associated OpenStack
+                                Security Group Role.
+                                For now this is only used for the allNodesSecurityGroupRules but when we add
+                                other security groups, we'll need to add a validation because
+                                Remote* fields are mutually exclusive.
+                              properties:
+                                description:
+                                  description: description of the security group rule.
+                                  type: string
+                                direction:
+                                  description: |-
+                                    direction in which the security group rule is applied. The only values
+                                    allowed are "ingress" or "egress". For a compute instance, an ingress
+                                    security group rule is applied to incoming (ingress) traffic for that
+                                    instance. An egress rule is applied to traffic leaving the instance.
+                                  type: string
+                                etherType:
+                                  description: |-
+                                    etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the
+                                    ingress or egress rules.
+                                  type: string
+                                name:
+                                  description: |-
+                                    name of the security group rule.
+                                    It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
+                                  type: string
+                                portRangeMax:
+                                  description: |-
+                                    portRangeMax is a number in the range that is matched by the security group
+                                    rule. The portRangeMin attribute constrains the portRangeMax attribute.
+                                  type: integer
+                                portRangeMin:
+                                  description: |-
+                                    portRangeMin is a number in the range that is matched by the security group
+                                    rule. If the protocol is TCP or UDP, this value must be less than or equal
+                                    to the value of the portRangeMax attribute.
+                                  type: integer
+                                protocol:
+                                  description: protocol is the protocol that is matched
+                                    by the security group rule.
+                                  type: string
+                                remoteGroupID:
+                                  description: |-
+                                    remoteGroupID is the remote group ID to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  type: string
+                                remoteIPPrefix:
+                                  description: |-
+                                    remoteIPPrefix is the remote IP prefix to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  type: string
+                                remoteManagedGroups:
+                                  description: |-
+                                    remoteManagedGroups is the remote managed groups to be associated with this security group rule.
+                                    You can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.
+                                  items:
+                                    enum:
+                                    - bastion
+                                    - controlplane
+                                    - worker
+                                    type: string
+                                  type: array
+                              required:
+                              - direction
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        required:
+                        - allowAllInClusterTraffic
+                        type: object
+                      managedSubnets:
+                        description: |-
+                          ManagedSubnets describe OpenStack Subnets to be created. Cluster actuator will create a network,
+                          subnets with the defined CIDR, and a router connected to these subnets. Currently only one IPv4
+                          subnet is supported. If you leave this empty, no network will be created.
+                        items:
+                          properties:
+                            allocationPools:
+                              description: |-
+                                AllocationPools is an array of AllocationPool objects that will be applied to OpenStack Subnet being created.
+                                If set, OpenStack will only allocate these IPs for Machines. It will still be possible to create ports from
+                                outside of these ranges manually.
+                              items:
+                                properties:
+                                  end:
+                                    description: End represents the end of the AlloctionPool,
+                                      that is the highest IP of the pool.
+                                    type: string
+                                  start:
+                                    description: Start represents the start of the
+                                      AllocationPool, that is the lowest IP of the
+                                      pool.
+                                    type: string
+                                required:
+                                - end
+                                - start
+                                type: object
+                              type: array
+                            cidr:
+                              description: |-
+                                CIDR is representing the IP address range used to create the subnet, e.g. 10.0.0.0/24.
+                                This field is required when defining a subnet.
+                              type: string
+                            dnsNameservers:
+                              description: |-
+                                DNSNameservers holds a list of DNS server addresses that will be provided when creating
+                                the subnet. These addresses need to have the same IP version as CIDR.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - cidr
+                          type: object
+                        maxItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      network:
+                        description: |-
+                          Network specifies an existing network to use if no ManagedSubnets
+                          are specified.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a filter to select an OpenStack
+                              network. If provided, cannot be empty.
+                            minProperties: 1
+                            properties:
+                              description:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                description: |-
+                                  NotTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the ID of the network to use. If ID
+                              is provided, the other filters cannot be provided. Must
+                              be in UUID format.
+                            format: uuid
+                            type: string
+                        type: object
+                      networkMTU:
+                        description: |-
+                          NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
+                          This value will be used only if the Cluster actuator creates the network.
+                          If left empty, the network will have the default MTU defined in Openstack network service.
+                          To use this field, the Openstack installation requires the net-mtu neutron API extension.
+                        type: integer
+                      router:
+                        description: |-
+                          Router specifies an existing router to be used if ManagedSubnets are
+                          specified. If specified, no new router will be created.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a filter to select an OpenStack
+                              router. If provided, cannot be empty.
+                            minProperties: 1
+                            properties:
+                              description:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                description: |-
+                                  NotTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the ID of the router to use. If ID
+                              is provided, the other filters cannot be provided. Must
+                              be in UUID format.
+                            format: uuid
+                            type: string
+                        type: object
+                      subnets:
+                        description: |-
+                          Subnets specifies existing subnets to use if not ManagedSubnets are
+                          specified. All subnets must be in the network specified by Network.
+                          There can be zero, one, or two subnets. If no subnets are specified,
+                          all subnets in Network will be used. If 2 subnets are specified, one
+                          must be IPv4 and the other IPv6.
+                        items:
+                          description: SubnetParam specifies an OpenStack subnet to
+                            use. It may be specified by either ID or filter, but not
+                            both.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            filter:
+                              description: Filter specifies a filter to select the
+                                subnet. It must match exactly one subnet.
+                              minProperties: 1
+                              properties:
+                                cidr:
+                                  type: string
+                                description:
+                                  type: string
+                                gatewayIP:
+                                  type: string
+                                ipVersion:
+                                  type: integer
+                                ipv6AddressMode:
+                                  type: string
+                                ipv6RAMode:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  description: |-
+                                    NotTags is a list of tags to filter by. If specified, resources which
+                                    contain all of the given tags will be excluded from the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                notTagsAny:
+                                  description: |-
+                                    NotTagsAny is a list of tags to filter by. If specified, resources
+                                    which contain any of the given tags will be excluded from the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                projectID:
+                                  type: string
+                                tags:
+                                  description: |-
+                                    Tags is a list of tags to filter by. If specified, the resource must
+                                    have all of the tags specified to be included in the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                tagsAny:
+                                  description: |-
+                                    TagsAny is a list of tags to filter by. If specified, the resource
+                                    must have at least one of the tags specified to be included in the
+                                    result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                            id:
+                              description: ID is the uuid of the subnet. It will not
+                                be validated.
+                              format: uuid
+                              type: string
+                          type: object
+                        maxItems: 2
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tags:
+                        description: Tags to set on all resources in cluster which
+                          support tags
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    required:
+                    - identityRef
+                    type: object
+                    x-kubernetes-validations:
+                    - message: bastion floating IP cannot be set when disableExternalNetwork
+                        is true
+                      rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+                        ? !has(self.bastion) || !has(self.bastion.floatingIP) : true'
+                    - message: disableAPIServerFloatingIP cannot be false when disableExternalNetwork
+                        is true
+                      rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+                        ? has(self.disableAPIServerFloatingIP) && self.disableAPIServerFloatingIP
+                        : true'
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    cluster.x-k8s.io/v1beta1: v1alpha7_v1beta1
+  name: openstackfloatingippools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OpenStackFloatingIPPool
+    listKind: OpenStackFloatingIPPoolList
+    plural: openstackfloatingippools
+    singular: openstackfloatingippool
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackFloatingIPPool is the Schema for the openstackfloatingippools
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackFloatingIPPoolSpec defines the desired state of
+              OpenStackFloatingIPPool.
+            properties:
+              floatingIPNetwork:
+                description: FloatingIPNetwork is the external network to use for
+                  floating ips, if there's only one external network it will be used
+                  by default
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a filter to select an OpenStack
+                      network. If provided, cannot be empty.
+                    minProperties: 1
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                      notTags:
+                        description: |-
+                          NotTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          NotTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      projectID:
+                        type: string
+                      tags:
+                        description: |-
+                          Tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          TagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the ID of the network to use. If ID is provided,
+                      the other filters cannot be provided. Must be in UUID format.
+                    format: uuid
+                    type: string
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when
+                  reconciling this pool.
+                properties:
+                  cloudName:
+                    description: CloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
+                required:
+                - cloudName
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
+              maxIPs:
+                description: |-
+                  MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.
+                  If set, the pool will stop allocating floating ips when it reaches this number of ClaimedIPs.
+                type: integer
+              preAllocatedFloatingIPs:
+                description: |-
+                  PreAllocatedFloatingIPs is a list of floating IPs precreated in OpenStack that should be used by this pool.
+                  These are used before allocating new ones and are not deleted from OpenStack when the pool is deleted.
+                items:
+                  type: string
+                type: array
+              reclaimPolicy:
+                description: The stratergy to use for reclaiming floating ips when
+                  they are released from a machine
+                enum:
+                - Retain
+                - Delete
+                type: string
+            required:
+            - identityRef
+            - reclaimPolicy
+            type: object
+          status:
+            description: OpenStackFloatingIPPoolStatus defines the observed state
+              of OpenStackFloatingIPPool.
+            properties:
+              availableIPs:
+                default: []
+                items:
+                  type: string
+                type: array
+              claimedIPs:
+                default: []
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failedIPs:
+                description: FailedIPs contains a list of floating ips that failed
+                  to be allocated
+                items:
+                  type: string
+                type: array
+              floatingIPNetwork:
+                description: floatingIPNetwork contains information about the network
+                  used for floating ips
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                - name
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    cluster.x-k8s.io/v1beta1: v1alpha7_v1beta1
+  name: openstackmachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capo-webhook-service
+          namespace: capo-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OpenStackMachine
+    listKind: OpenStackMachineList
+    plural: openstackmachines
+    shortNames:
+    - osm
+    singular: openstackmachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this OpenStackMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: OpenStack instance state
+      jsonPath: .status.instanceState
+      name: InstanceState
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: OpenStack instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns with this OpenStackMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Time duration since creation of OpenStackMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha7 version of OpenStackMachine has been deprecated
+      and will be removed in a future release.
+    name: v1alpha7
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OpenStackMachine is the Schema for the openstackmachines API.
+
+          Deprecated: v1alpha7.OpenStackMachine has been replaced by v1beta1.OpenStackMachine.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackMachineSpec defines the desired state of OpenStackMachine.
+            properties:
+              additionalBlockDevices:
+                description: AdditionalBlockDevices is a list of specifications for
+                  additional block devices to attach to the server instance
+                items:
+                  description: AdditionalBlockDevice is a block device to attach to
+                    the server.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the block device in the context of a machine.
+                        If the block device is a volume, the Cinder volume will be named
+                        as a combination of the machine name and this name.
+                        Also, this name will be used for tagging the block device.
+                        Information about the block device tag can be obtained from the OpenStack
+                        metadata API or the config drive.
+                      type: string
+                    sizeGiB:
+                      description: SizeGiB is the size of the block device in gibibytes
+                        (GiB).
+                      type: integer
+                    storage:
+                      description: |-
+                        Storage specifies the storage type of the block device and
+                        additional storage options.
+                      properties:
+                        type:
+                          description: |-
+                            Type is the type of block device to create.
+                            This can be either "Volume" or "Local".
+                          type: string
+                        volume:
+                          description: Volume contains additional storage options
+                            for a volume block device.
+                          properties:
+                            availabilityZone:
+                              description: |-
+                                AvailabilityZone is the volume availability zone to create the volume in.
+                                If omitted, the availability zone of the server will be used.
+                                The availability zone must NOT contain spaces otherwise it will lead to volume that belongs
+                                to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for
+                                further information.
+                              type: string
+                            type:
+                              description: |-
+                                Type is the Cinder volume type of the volume.
+                                If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                will be used.
+                              type: string
+                          type: object
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - name
+                  - sizeGiB
+                  - storage
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              cloudName:
+                description: The name of the cloud to use from the clouds secret
+                type: string
+              configDrive:
+                description: Config Drive support
+                type: boolean
+              flavor:
+                description: The flavor reference for the flavor for your server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
+                type: string
+              floatingIP:
+                description: |-
+                  The floatingIP which will be associated to the machine, only used for master.
+                  The floatingIP should have been created and haven't been associated.
+                type: string
+              identityRef:
+                description: |-
+                  IdentityRef is a reference to a identity to be used when reconciling this cluster.
+                  If not specified, the identity ref of the cluster will be used instead.
+                properties:
+                  kind:
+                    description: |-
+                      Kind of the identity. Must be supported by the infrastructure
+                      provider and may be either cluster or namespace-scoped.
+                    minLength: 1
+                    type: string
+                  name:
+                    description: |-
+                      Name of the infrastructure identity to be used.
+                      Must be either a cluster-scoped resource, or namespaced-scoped
+                      resource the same namespace as the resource(s) being provisioned.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              image:
+                description: |-
+                  The name of the image to use for your server instance.
+                  If the RootVolume is specified, this will be ignored and use rootVolume directly.
+                type: string
+              imageUUID:
+                description: |-
+                  The uuid of the image to use for your server instance.
+                  if it's empty, Image name will be used
+                type: string
+              instanceID:
+                description: InstanceID is the OpenStack instance ID for this machine.
+                type: string
+              ports:
+                description: |-
+                  Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                  If not specified a default port will be added for the default cluster network.
+                items:
+                  properties:
+                    adminStateUp:
+                      type: boolean
+                    allowedAddressPairs:
+                      items:
+                        properties:
+                          ipAddress:
+                            type: string
+                          macAddress:
+                            type: string
+                        type: object
+                      type: array
+                    description:
+                      type: string
+                    disablePortSecurity:
+                      description: |-
+                        DisablePortSecurity enables or disables the port security when set.
+                        When not set, it takes the value of the corresponding field at the network level.
+                      type: boolean
+                    fixedIPs:
+                      description: Specify pairs of subnet and/or IP address. These
+                        should be subnets of the network with the given NetworkID.
+                      items:
+                        properties:
+                          ipAddress:
+                            type: string
+                          subnet:
+                            description: |-
+                              Subnet is an openstack subnet query that will return the id of a subnet to create
+                              the fixed IP of a port in. This query must not return more than one subnet.
+                            properties:
+                              cidr:
+                                type: string
+                              description:
+                                type: string
+                              gateway_ip:
+                                type: string
+                              id:
+                                type: string
+                              ipVersion:
+                                type: integer
+                              ipv6AddressMode:
+                                type: string
+                              ipv6RaMode:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                type: string
+                              notTagsAny:
+                                type: string
+                              projectId:
+                                type: string
+                              tags:
+                                type: string
+                              tagsAny:
+                                type: string
+                            type: object
+                        required:
+                        - subnet
+                        type: object
+                      type: array
+                    hostId:
+                      description: The ID of the host where the port is allocated
+                      type: string
+                    macAddress:
+                      type: string
+                    nameSuffix:
+                      description: Used to make the name of the port unique. If unspecified,
+                        instead the 0-based index of the port in the list is used.
+                      type: string
+                    network:
+                      description: |-
+                        Network is a query for an openstack network that the port will be created or discovered on.
+                        This will fail if the query returns more than one network.
+                      properties:
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        notTags:
+                          type: string
+                        notTagsAny:
+                          type: string
+                        projectId:
+                          type: string
+                        tags:
+                          type: string
+                        tagsAny:
+                          type: string
+                      type: object
+                    profile:
+                      description: |-
+                        Profile is a set of key-value pairs that are used for binding details.
+                        We intentionally don't expose this as a map[string]string because we only want to enable
+                        the users to set the values of the keys that are known to work in OpenStack Networking API.
+                        See https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                      properties:
+                        ovsHWOffload:
+                          description: OVSHWOffload enables or disables the OVS hardware
+                            offload feature.
+                          type: boolean
+                        trustedVF:
+                          description: TrustedVF enables or disables the “trusted
+                            mode” for the VF.
+                          type: boolean
+                      type: object
+                    propagateUplinkStatus:
+                      description: PropageteUplinkStatus enables or disables the propagate
+                        uplink status on the port.
+                      type: boolean
+                    securityGroupFilters:
+                      description: The names, uuids, filters or any combination these
+                        of the security groups to assign to the instance
+                      items:
+                        properties:
+                          description:
+                            type: string
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          notTags:
+                            type: string
+                          notTagsAny:
+                            type: string
+                          projectId:
+                            type: string
+                          tags:
+                            type: string
+                          tagsAny:
+                            type: string
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                        These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    trunk:
+                      description: Enables and disables trunk at port level. If not
+                        provided, openStackMachine.Spec.Trunk is inherited.
+                      type: boolean
+                    valueSpecs:
+                      description: |-
+                        Value specs are extra parameters to include in the API request with OpenStack.
+                        This is an extension point for the API, so what they do and if they are supported,
+                        depends on the specific OpenStack implementation.
+                      items:
+                        description: ValueSpec represents a single value_spec key-value
+                          pair.
+                        properties:
+                          key:
+                            description: Key is the key in the key-value pair.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the key-value pair.
+                              This is just for identifying the pair and will not be sent to the OpenStack API.
+                            type: string
+                          value:
+                            description: Value is the value in the key-value pair.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    vnicType:
+                      description: The virtual network interface card (vNIC) type
+                        that is bound to the neutron port.
+                      type: string
+                  type: object
+                type: array
+              providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
+                type: string
+              rootVolume:
+                description: The volume metadata to boot from
+                properties:
+                  availabilityZone:
+                    type: string
+                  diskSize:
+                    type: integer
+                  volumeType:
+                    type: string
+                type: object
+              securityGroups:
+                description: The names of the security groups to assign to the instance
+                items:
+                  properties:
+                    description:
+                      type: string
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    notTags:
+                      type: string
+                    notTagsAny:
+                      type: string
+                    projectId:
+                      type: string
+                    tags:
+                      type: string
+                    tagsAny:
+                      type: string
+                  type: object
+                type: array
+              serverGroupID:
+                description: The server group to assign the machine to
+                type: string
+              serverMetadata:
+                additionalProperties:
+                  type: string
+                description: Metadata mapping. Allows you to create a map of key value
+                  pairs to add to the server instance.
+                type: object
+              sshKeyName:
+                description: The ssh key to inject in the instance
+                type: string
+              tags:
+                description: |-
+                  Machine tags
+                  Requires Nova api 2.52 minimum!
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              trunk:
+                description: Whether the server instance is created on a trunk port
+                  or not.
+                type: boolean
+            type: object
+          status:
+            description: OpenStackMachineStatus defines the observed state of OpenStackMachine.
+            properties:
+              addresses:
+                description: Addresses contains the OpenStack instance associated
+                  addresses.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
+                      type: string
+                    type:
+                      description: Node address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: DeprecatedCAPIMachineStatusError defines errors states
+                  for Machine objects.
+                type: string
+              instanceState:
+                description: InstanceState is the state of the OpenStack instance
+                  for this machine.
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this OpenStackMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: OpenStack instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns with this OpenStackMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Time duration since creation of OpenStackMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackMachine is the Schema for the openstackmachines API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackMachineSpec defines the desired state of OpenStackMachine.
+            properties:
+              additionalBlockDevices:
+                description: AdditionalBlockDevices is a list of specifications for
+                  additional block devices to attach to the server instance
+                items:
+                  description: AdditionalBlockDevice is a block device to attach to
+                    the server.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the block device in the context of a machine.
+                        If the block device is a volume, the Cinder volume will be named
+                        as a combination of the machine name and this name.
+                        Also, this name will be used for tagging the block device.
+                        Information about the block device tag can be obtained from the OpenStack
+                        metadata API or the config drive.
+                        Name cannot be 'root', which is reserved for the root volume.
+                      type: string
+                    sizeGiB:
+                      description: SizeGiB is the size of the block device in gibibytes
+                        (GiB).
+                      minimum: 1
+                      type: integer
+                    storage:
+                      description: |-
+                        Storage specifies the storage type of the block device and
+                        additional storage options.
+                      properties:
+                        type:
+                          description: |-
+                            Type is the type of block device to create.
+                            This can be either "Volume" or "Local".
+                          type: string
+                        volume:
+                          description: Volume contains additional storage options
+                            for a volume block device.
+                          properties:
+                            availabilityZone:
+                              description: |-
+                                AvailabilityZone is the volume availability zone to create the volume
+                                in. If not specified, the volume will be created without an explicit
+                                availability zone.
+                              properties:
+                                from:
+                                  default: Name
+                                  description: |-
+                                    From specifies where we will obtain the availability zone for the
+                                    volume. The options are "Name" and "Machine". If "Name" is specified
+                                    then the Name field must also be specified. If "Machine" is specified
+                                    the volume will use the value of FailureDomain, if any, from the
+                                    associated Machine.
+                                  enum:
+                                  - Name
+                                  - Machine
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name is the name of a volume availability zone to use. It is required
+                                    if From is "Name". The volume availability zone name may not contain
+                                    spaces.
+                                  minLength: 1
+                                  pattern: ^[^ ]+$
+                                  type: string
+                              type: object
+                              x-kubernetes-validations:
+                              - message: name is required when from is 'Name' or default
+                                rule: '!has(self.from) || self.from == ''Name'' ?
+                                  has(self.name) : !has(self.name)'
+                            type:
+                              description: |-
+                                Type is the Cinder volume type of the volume.
+                                If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                will be used.
+                              type: string
+                          type: object
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - name
+                  - sizeGiB
+                  - storage
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              configDrive:
+                description: Config Drive support
+                type: boolean
+              flavor:
+                description: The flavor reference for the flavor for your server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
+                type: string
+              floatingIPPoolRef:
+                description: |-
+                  floatingIPPoolRef is a reference to a IPPool that will be assigned
+                  to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
+                  will be assigned to the OpenStackMachine.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              identityRef:
+                description: |-
+                  IdentityRef is a reference to a secret holding OpenStack credentials
+                  to be used when reconciling this machine. If not specified, the
+                  credentials specified in the cluster will be used.
+                properties:
+                  cloudName:
+                    description: CloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
+                required:
+                - cloudName
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
+              image:
+                description: |-
+                  The image to use for your server instance.
+                  If the rootVolume is specified, this will be used when creating the root volume.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      Filter describes a query for an image. If specified, the combination
+                      of name and tags must return a single matching image or an error will
+                      be raised.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: The name of the desired image. If specified,
+                          the combination of name and tags must return a single matching
+                          image or an error will be raised.
+                        type: string
+                      tags:
+                        description: The tags associated with the desired image. If
+                          specified, the combination of name and tags must return
+                          a single matching image or an error will be raised.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the uuid of the image. ID will not be validated
+                      before use.
+                    format: uuid
+                    type: string
+                  imageRef:
+                    description: |-
+                      ImageRef is a reference to an ORC Image in the same namespace as the
+                      referring object.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced resource
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              ports:
+                description: |-
+                  Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                  If not specified a default port will be added for the default cluster network.
+                items:
+                  properties:
+                    adminStateUp:
+                      description: AdminStateUp specifies whether the port should
+                        be created in the up (true) or down (false) state. The default
+                        is up.
+                      type: boolean
+                    allowedAddressPairs:
+                      description: |-
+                        AllowedAddressPairs is a list of address pairs which Neutron will
+                        allow the port to send traffic from in addition to the port's
+                        addresses. If not specified, the MAC Address will be the MAC Address
+                        of the port. Depending on the configuration of Neutron, it may be
+                        supported to specify a CIDR instead of a specific IP address.
+                      items:
+                        properties:
+                          ipAddress:
+                            description: |-
+                              IPAddress is the IP address of the allowed address pair. Depending on
+                              the configuration of Neutron, it may be supported to specify a CIDR
+                              instead of a specific IP address.
+                            type: string
+                          macAddress:
+                            description: |-
+                              MACAddress is the MAC address of the allowed address pair. If not
+                              specified, the MAC address will be the MAC address of the port.
+                            type: string
+                        required:
+                        - ipAddress
+                        type: object
+                      type: array
+                    description:
+                      description: Description is a human-readable description for
+                        the port.
+                      type: string
+                    disablePortSecurity:
+                      description: |-
+                        DisablePortSecurity enables or disables the port security when set.
+                        When not set, it takes the value of the corresponding field at the network level.
+                      type: boolean
+                    fixedIPs:
+                      description: FixedIPs is a list of pairs of subnet and/or IP
+                        address to assign to the port. If specified, these must be
+                        subnets of the port's network.
+                      items:
+                        properties:
+                          ipAddress:
+                            description: |-
+                              IPAddress is a specific IP address to assign to the port. If Subnet
+                              is also specified, IPAddress must be a valid IP address in the
+                              subnet. If Subnet is not specified, IPAddress must be a valid IP
+                              address in any subnet of the port's network.
+                            type: string
+                          subnet:
+                            description: |-
+                              Subnet is an openstack subnet query that will return the id of a subnet to create
+                              the fixed IP of a port in. This query must not return more than one subnet.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              filter:
+                                description: Filter specifies a filter to select the
+                                  subnet. It must match exactly one subnet.
+                                minProperties: 1
+                                properties:
+                                  cidr:
+                                    type: string
+                                  description:
+                                    type: string
+                                  gatewayIP:
+                                    type: string
+                                  ipVersion:
+                                    type: integer
+                                  ipv6AddressMode:
+                                    type: string
+                                  ipv6RAMode:
+                                    type: string
+                                  name:
+                                    type: string
+                                  notTags:
+                                    description: |-
+                                      NotTags is a list of tags to filter by. If specified, resources which
+                                      contain all of the given tags will be excluded from the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  notTagsAny:
+                                    description: |-
+                                      NotTagsAny is a list of tags to filter by. If specified, resources
+                                      which contain any of the given tags will be excluded from the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  projectID:
+                                    type: string
+                                  tags:
+                                    description: |-
+                                      Tags is a list of tags to filter by. If specified, the resource must
+                                      have all of the tags specified to be included in the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  tagsAny:
+                                    description: |-
+                                      TagsAny is a list of tags to filter by. If specified, the resource
+                                      must have at least one of the tags specified to be included in the
+                                      result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                type: object
+                              id:
+                                description: ID is the uuid of the subnet. It will
+                                  not be validated.
+                                format: uuid
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    hostID:
+                      description: HostID specifies the ID of the host where the port
+                        resides.
+                      type: string
+                    macAddress:
+                      description: MACAddress specifies the MAC address of the port.
+                        If not specified, the MAC address will be generated.
+                      type: string
+                    nameSuffix:
+                      description: NameSuffix will be appended to the name of the
+                        port if specified. If unspecified, instead the 0-based index
+                        of the port in the list is used.
+                      type: string
+                    network:
+                      description: |-
+                        Network is a query for an openstack network that the port will be created or discovered on.
+                        This will fail if the query returns more than one network.
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        filter:
+                          description: Filter specifies a filter to select an OpenStack
+                            network. If provided, cannot be empty.
+                          minProperties: 1
+                          properties:
+                            description:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              description: |-
+                                NotTags is a list of tags to filter by. If specified, resources which
+                                contain all of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            notTagsAny:
+                              description: |-
+                                NotTagsAny is a list of tags to filter by. If specified, resources
+                                which contain any of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            projectID:
+                              type: string
+                            tags:
+                              description: |-
+                                Tags is a list of tags to filter by. If specified, the resource must
+                                have all of the tags specified to be included in the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            tagsAny:
+                              description: |-
+                                TagsAny is a list of tags to filter by. If specified, the resource
+                                must have at least one of the tags specified to be included in the
+                                result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          type: object
+                        id:
+                          description: ID is the ID of the network to use. If ID is
+                            provided, the other filters cannot be provided. Must be
+                            in UUID format.
+                          format: uuid
+                          type: string
+                      type: object
+                    profile:
+                      description: |-
+                        Profile is a set of key-value pairs that are used for binding
+                        details. We intentionally don't expose this as a map[string]string
+                        because we only want to enable the users to set the values of the
+                        keys that are known to work in OpenStack Networking API.  See
+                        https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                        To set profiles, your tenant needs permissions rule:create_port, and
+                        rule:create_port:binding:profile
+                      properties:
+                        ovsHWOffload:
+                          description: |-
+                            OVSHWOffload enables or disables the OVS hardware offload feature.
+                            This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                            See: https://bugs.launchpad.net/nova/+bug/2020813
+                          type: boolean
+                        trustedVF:
+                          description: TrustedVF enables or disables the “trusted
+                            mode” for the VF.
+                          type: boolean
+                      type: object
+                    propagateUplinkStatus:
+                      description: PropageteUplinkStatus enables or disables the propagate
+                        uplink status on the port.
+                      type: boolean
+                    securityGroups:
+                      description: SecurityGroups is a list of the names, uuids, filters
+                        or any combination these of the security groups to assign
+                        to the instance.
+                      items:
+                        description: SecurityGroupParam specifies an OpenStack security
+                          group. It may be specified by ID or filter, but not both.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a query to select an OpenStack
+                              security group. If provided, cannot be empty.
+                            minProperties: 1
+                            properties:
+                              description:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                description: |-
+                                  NotTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the ID of the security group to use.
+                              If ID is provided, the other filters cannot be provided.
+                              Must be in UUID format.
+                            format: uuid
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    tags:
+                      description: |-
+                        Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                        These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    trunk:
+                      description: |-
+                        Trunk specifies whether trunking is enabled at the port level. If not
+                        provided the value is inherited from the machine, or false for a
+                        bastion host.
+                      type: boolean
+                    valueSpecs:
+                      description: |-
+                        Value specs are extra parameters to include in the API request with OpenStack.
+                        This is an extension point for the API, so what they do and if they are supported,
+                        depends on the specific OpenStack implementation.
+                      items:
+                        description: ValueSpec represents a single value_spec key-value
+                          pair.
+                        properties:
+                          key:
+                            description: Key is the key in the key-value pair.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the key-value pair.
+                              This is just for identifying the pair and will not be sent to the OpenStack API.
+                            type: string
+                          value:
+                            description: Value is the value in the key-value pair.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    vnicType:
+                      description: |-
+                        VNICType specifies the type of vNIC which this port should be
+                        attached to. This is used to determine which mechanism driver(s) to
+                        be used to bind the port. The valid values are normal, macvtap,
+                        direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                        remote-managed, although these values will not be validated in this
+                        API to ensure compatibility with future neutron changes or custom
+                        implementations. What type of vNIC is actually available depends on
+                        deployments. If not specified, the Neutron default value is used.
+                      type: string
+                  type: object
+                type: array
+              providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
+                type: string
+              rootVolume:
+                description: The volume metadata to boot from
+                properties:
+                  availabilityZone:
+                    description: |-
+                      AvailabilityZone is the volume availability zone to create the volume
+                      in. If not specified, the volume will be created without an explicit
+                      availability zone.
+                    properties:
+                      from:
+                        default: Name
+                        description: |-
+                          From specifies where we will obtain the availability zone for the
+                          volume. The options are "Name" and "Machine". If "Name" is specified
+                          then the Name field must also be specified. If "Machine" is specified
+                          the volume will use the value of FailureDomain, if any, from the
+                          associated Machine.
+                        enum:
+                        - Name
+                        - Machine
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of a volume availability zone to use. It is required
+                          if From is "Name". The volume availability zone name may not contain
+                          spaces.
+                        minLength: 1
+                        pattern: ^[^ ]+$
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when from is 'Name' or default
+                      rule: '!has(self.from) || self.from == ''Name'' ? has(self.name)
+                        : !has(self.name)'
+                  sizeGiB:
+                    description: SizeGiB is the size of the block device in gibibytes
+                      (GiB).
+                    minimum: 1
+                    type: integer
+                  type:
+                    description: |-
+                      Type is the Cinder volume type of the volume.
+                      If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                      will be used.
+                    type: string
+                required:
+                - sizeGiB
+                type: object
+              schedulerHintAdditionalProperties:
+                description: |-
+                  SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints
+                  to the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,
+                  such as specifying certain host aggregates or availability zones.
+                items:
+                  description: |-
+                    SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.
+                    It includes a Name to identify the property and a Value that can be of various types.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the scheduler hint property.
+                        It is a unique identifier for the property.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: |-
+                        Value is the value of the scheduler hint property, which can be of various types
+                        (e.g., bool, string, int). The type is indicated by the Value.Type field.
+                      properties:
+                        bool:
+                          description: |-
+                            Bool is the boolean value of the scheduler hint, used when Type is "Bool".
+                            This field is required if type is 'Bool', and must not be set otherwise.
+                          type: boolean
+                        number:
+                          description: |-
+                            Number is the integer value of the scheduler hint, used when Type is "Number".
+                            This field is required if type is 'Number', and must not be set otherwise.
+                          type: integer
+                        string:
+                          description: |-
+                            String is the string value of the scheduler hint, used when Type is "String".
+                            This field is required if type is 'String', and must not be set otherwise.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        type:
+                          description: |-
+                            Type represents the type of the value.
+                            Valid values are Bool, String, and Number.
+                          enum:
+                          - Bool
+                          - String
+                          - Number
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: bool is required when type is Bool, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Bool'' ? has(self.bool)
+                          : !has(self.bool)'
+                      - message: number is required when type is Number, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Number'' ? has(self.number)
+                          : !has(self.number)'
+                      - message: string is required when type is String, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''String'' ? has(self.string)
+                          : !has(self.string)'
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              securityGroups:
+                description: The names of the security groups to assign to the instance
+                items:
+                  description: SecurityGroupParam specifies an OpenStack security
+                    group. It may be specified by ID or filter, but not both.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: Filter specifies a query to select an OpenStack
+                        security group. If provided, cannot be empty.
+                      minProperties: 1
+                      properties:
+                        description:
+                          type: string
+                        name:
+                          type: string
+                        notTags:
+                          description: |-
+                            NotTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            NotTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        projectID:
+                          type: string
+                        tags:
+                          description: |-
+                            Tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            TagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: ID is the ID of the security group to use. If ID
+                        is provided, the other filters cannot be provided. Must be
+                        in UUID format.
+                      format: uuid
+                      type: string
+                  type: object
+                type: array
+              serverGroup:
+                description: The server group to assign the machine to.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a query to select an OpenStack server
+                      group. If provided, it cannot be empty.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: Name is the name of a server group to look for.
+                        type: string
+                    type: object
+                  id:
+                    description: ID is the ID of the server group to use.
+                    format: uuid
+                    type: string
+                type: object
+              serverMetadata:
+                description: Metadata mapping. Allows you to create a map of key value
+                  pairs to add to the server instance.
+                items:
+                  properties:
+                    key:
+                      description: Key is the server metadata key
+                      maxLength: 255
+                      type: string
+                    value:
+                      description: Value is the server metadata value
+                      maxLength: 255
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
+              sshKeyName:
+                description: The ssh key to inject in the instance
+                type: string
+              tags:
+                description: |-
+                  Tags which will be added to the machine and all dependent resources
+                  which support them. These are in addition to Tags defined on the
+                  cluster.
+                  Requires Nova api 2.52 minimum!
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              trunk:
+                description: Whether the server instance is created on a trunk port
+                  or not.
+                type: boolean
+            required:
+            - image
+            type: object
+            x-kubernetes-validations:
+            - message: at least one of flavor or flavorID must be set
+              rule: (has(self.flavor) || has(self.flavorID))
+          status:
+            description: OpenStackMachineStatus defines the observed state of OpenStackMachine.
+            properties:
+              addresses:
+                description: Addresses contains the OpenStack instance associated
+                  addresses.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
+                      type: string
+                    type:
+                      description: Node address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: DeprecatedCAPIMachineStatusError defines errors states
+                  for Machine objects.
+                type: string
+              instanceID:
+                description: InstanceID is the OpenStack instance ID for this machine.
+                type: string
+              instanceState:
+                description: |-
+                  InstanceState is the state of the OpenStack instance for this machine.
+                  This field is not set anymore by the OpenStackMachine controller.
+                  Instead, it's set by the OpenStackServer controller.
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+              resolved:
+                description: |-
+                  Resolved contains parts of the machine spec with all external
+                  references fully resolved.
+                properties:
+                  flavorID:
+                    description: FlavorID is the ID of the flavor to use.
+                    type: string
+                  imageID:
+                    description: ImageID is the ID of the image to use for the machine
+                      and is calculated based on ImageFilter.
+                    type: string
+                  ports:
+                    description: Ports is the fully resolved list of ports to create
+                      for the machine.
+                    items:
+                      description: ResolvedPortSpec is a PortOpts with all contained
+                        references fully resolved.
+                      properties:
+                        adminStateUp:
+                          description: AdminStateUp specifies whether the port should
+                            be created in the up (true) or down (false) state. The
+                            default is up.
+                          type: boolean
+                        allowedAddressPairs:
+                          description: |-
+                            AllowedAddressPairs is a list of address pairs which Neutron will
+                            allow the port to send traffic from in addition to the port's
+                            addresses. If not specified, the MAC Address will be the MAC Address
+                            of the port. Depending on the configuration of Neutron, it may be
+                            supported to specify a CIDR instead of a specific IP address.
+                          items:
+                            properties:
+                              ipAddress:
+                                description: |-
+                                  IPAddress is the IP address of the allowed address pair. Depending on
+                                  the configuration of Neutron, it may be supported to specify a CIDR
+                                  instead of a specific IP address.
+                                type: string
+                              macAddress:
+                                description: |-
+                                  MACAddress is the MAC address of the allowed address pair. If not
+                                  specified, the MAC address will be the MAC address of the port.
+                                type: string
+                            required:
+                            - ipAddress
+                            type: object
+                          type: array
+                        description:
+                          description: Description is a human-readable description
+                            for the port.
+                          type: string
+                        disablePortSecurity:
+                          description: |-
+                            DisablePortSecurity enables or disables the port security when set.
+                            When not set, it takes the value of the corresponding field at the network level.
+                          type: boolean
+                        fixedIPs:
+                          description: FixedIPs is a list of pairs of subnet and/or
+                            IP address to assign to the port. If specified, these
+                            must be subnets of the port's network.
+                          items:
+                            description: ResolvedFixedIP is a FixedIP with the Subnet
+                              resolved to an ID.
+                            properties:
+                              ipAddress:
+                                description: |-
+                                  IPAddress is a specific IP address to assign to the port. If SubnetID
+                                  is also specified, IPAddress must be a valid IP address in the
+                                  subnet. If Subnet is not specified, IPAddress must be a valid IP
+                                  address in any subnet of the port's network.
+                                type: string
+                              subnet:
+                                description: SubnetID is the id of a subnet to create
+                                  the fixed IP of a port in.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        hostID:
+                          description: HostID specifies the ID of the host where the
+                            port resides.
+                          type: string
+                        macAddress:
+                          description: MACAddress specifies the MAC address of the
+                            port. If not specified, the MAC address will be generated.
+                          type: string
+                        name:
+                          description: Name is the name of the port.
+                          type: string
+                        networkID:
+                          description: NetworkID is the ID of the network the port
+                            will be created in.
+                          type: string
+                        profile:
+                          description: |-
+                            Profile is a set of key-value pairs that are used for binding
+                            details. We intentionally don't expose this as a map[string]string
+                            because we only want to enable the users to set the values of the
+                            keys that are known to work in OpenStack Networking API.  See
+                            https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                            To set profiles, your tenant needs permissions rule:create_port, and
+                            rule:create_port:binding:profile
+                          properties:
+                            ovsHWOffload:
+                              description: |-
+                                OVSHWOffload enables or disables the OVS hardware offload feature.
+                                This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                                See: https://bugs.launchpad.net/nova/+bug/2020813
+                              type: boolean
+                            trustedVF:
+                              description: TrustedVF enables or disables the “trusted
+                                mode” for the VF.
+                              type: boolean
+                          type: object
+                        propagateUplinkStatus:
+                          description: PropageteUplinkStatus enables or disables the
+                            propagate uplink status on the port.
+                          type: boolean
+                        securityGroups:
+                          description: SecurityGroups is a list of security group
+                            IDs to assign to the port.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        tags:
+                          description: Tags applied to the port (and corresponding
+                            trunk, if a trunk is configured.)
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        trunk:
+                          description: Trunk specifies whether trunking is enabled
+                            at the port level.
+                          type: boolean
+                        valueSpecs:
+                          description: |-
+                            Value specs are extra parameters to include in the API request with OpenStack.
+                            This is an extension point for the API, so what they do and if they are supported,
+                            depends on the specific OpenStack implementation.
+                          items:
+                            description: ValueSpec represents a single value_spec
+                              key-value pair.
+                            properties:
+                              key:
+                                description: Key is the key in the key-value pair.
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of the key-value pair.
+                                  This is just for identifying the pair and will not be sent to the OpenStack API.
+                                type: string
+                              value:
+                                description: Value is the value in the key-value pair.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        vnicType:
+                          description: |-
+                            VNICType specifies the type of vNIC which this port should be
+                            attached to. This is used to determine which mechanism driver(s) to
+                            be used to bind the port. The valid values are normal, macvtap,
+                            direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                            remote-managed, although these values will not be validated in this
+                            API to ensure compatibility with future neutron changes or custom
+                            implementations. What type of vNIC is actually available depends on
+                            deployments. If not specified, the Neutron default value is used.
+                          type: string
+                      required:
+                      - description
+                      - name
+                      - networkID
+                      type: object
+                    type: array
+                  serverGroupID:
+                    description: ServerGroupID is the ID of the server group the machine
+                      should be added to and is calculated based on ServerGroupFilter.
+                    type: string
+                type: object
+              resources:
+                description: Resources contains references to OpenStack resources
+                  created for the machine.
+                properties:
+                  ports:
+                    description: Ports is the status of the ports created for the
+                      machine.
+                    items:
+                      properties:
+                        id:
+                          description: ID is the unique identifier of the port.
+                          type: string
+                      required:
+                      - id
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    cluster.x-k8s.io/v1beta1: v1alpha7_v1beta1
+  name: openstackmachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capo-webhook-service
+          namespace: capo-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OpenStackMachineTemplate
+    listKind: OpenStackMachineTemplateList
+    plural: openstackmachinetemplates
+    shortNames:
+    - osmt
+    singular: openstackmachinetemplate
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: The v1alpha7 version of OpenStackMachineTemplate has been
+      deprecated and will be removed in a future release.
+    name: v1alpha7
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OpenStackMachineTemplate is the Schema for the openstackmachinetemplates API.
+
+          Deprecated: v1alpha7.OpenStackMachineTemplate has been replaced by v1beta1.OpenStackMachineTemplate.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackMachineTemplateSpec defines the desired state of
+              OpenStackMachineTemplate.
+            properties:
+              template:
+                description: OpenStackMachineTemplateResource describes the data needed
+                  to create a OpenStackMachine from a template.
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalBlockDevices:
+                        description: AdditionalBlockDevices is a list of specifications
+                          for additional block devices to attach to the server instance
+                        items:
+                          description: AdditionalBlockDevice is a block device to
+                            attach to the server.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the block device in the context of a machine.
+                                If the block device is a volume, the Cinder volume will be named
+                                as a combination of the machine name and this name.
+                                Also, this name will be used for tagging the block device.
+                                Information about the block device tag can be obtained from the OpenStack
+                                metadata API or the config drive.
+                              type: string
+                            sizeGiB:
+                              description: SizeGiB is the size of the block device
+                                in gibibytes (GiB).
+                              type: integer
+                            storage:
+                              description: |-
+                                Storage specifies the storage type of the block device and
+                                additional storage options.
+                              properties:
+                                type:
+                                  description: |-
+                                    Type is the type of block device to create.
+                                    This can be either "Volume" or "Local".
+                                  type: string
+                                volume:
+                                  description: Volume contains additional storage
+                                    options for a volume block device.
+                                  properties:
+                                    availabilityZone:
+                                      description: |-
+                                        AvailabilityZone is the volume availability zone to create the volume in.
+                                        If omitted, the availability zone of the server will be used.
+                                        The availability zone must NOT contain spaces otherwise it will lead to volume that belongs
+                                        to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for
+                                        further information.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        Type is the Cinder volume type of the volume.
+                                        If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                        will be used.
+                                      type: string
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - sizeGiB
+                          - storage
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      cloudName:
+                        description: The name of the cloud to use from the clouds
+                          secret
+                        type: string
+                      configDrive:
+                        description: Config Drive support
+                        type: boolean
+                      flavor:
+                        description: The flavor reference for the flavor for your
+                          server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
+                        type: string
+                      floatingIP:
+                        description: |-
+                          The floatingIP which will be associated to the machine, only used for master.
+                          The floatingIP should have been created and haven't been associated.
+                        type: string
+                      identityRef:
+                        description: |-
+                          IdentityRef is a reference to a identity to be used when reconciling this cluster.
+                          If not specified, the identity ref of the cluster will be used instead.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind of the identity. Must be supported by the infrastructure
+                              provider and may be either cluster or namespace-scoped.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name of the infrastructure identity to be used.
+                              Must be either a cluster-scoped resource, or namespaced-scoped
+                              resource the same namespace as the resource(s) being provisioned.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      image:
+                        description: |-
+                          The name of the image to use for your server instance.
+                          If the RootVolume is specified, this will be ignored and use rootVolume directly.
+                        type: string
+                      imageUUID:
+                        description: |-
+                          The uuid of the image to use for your server instance.
+                          if it's empty, Image name will be used
+                        type: string
+                      instanceID:
+                        description: InstanceID is the OpenStack instance ID for this
+                          machine.
+                        type: string
+                      ports:
+                        description: |-
+                          Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                          If not specified a default port will be added for the default cluster network.
+                        items:
+                          properties:
+                            adminStateUp:
+                              type: boolean
+                            allowedAddressPairs:
+                              items:
+                                properties:
+                                  ipAddress:
+                                    type: string
+                                  macAddress:
+                                    type: string
+                                type: object
+                              type: array
+                            description:
+                              type: string
+                            disablePortSecurity:
+                              description: |-
+                                DisablePortSecurity enables or disables the port security when set.
+                                When not set, it takes the value of the corresponding field at the network level.
+                              type: boolean
+                            fixedIPs:
+                              description: Specify pairs of subnet and/or IP address.
+                                These should be subnets of the network with the given
+                                NetworkID.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    type: string
+                                  subnet:
+                                    description: |-
+                                      Subnet is an openstack subnet query that will return the id of a subnet to create
+                                      the fixed IP of a port in. This query must not return more than one subnet.
+                                    properties:
+                                      cidr:
+                                        type: string
+                                      description:
+                                        type: string
+                                      gateway_ip:
+                                        type: string
+                                      id:
+                                        type: string
+                                      ipVersion:
+                                        type: integer
+                                      ipv6AddressMode:
+                                        type: string
+                                      ipv6RaMode:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        type: string
+                                      notTagsAny:
+                                        type: string
+                                      projectId:
+                                        type: string
+                                      tags:
+                                        type: string
+                                      tagsAny:
+                                        type: string
+                                    type: object
+                                required:
+                                - subnet
+                                type: object
+                              type: array
+                            hostId:
+                              description: The ID of the host where the port is allocated
+                              type: string
+                            macAddress:
+                              type: string
+                            nameSuffix:
+                              description: Used to make the name of the port unique.
+                                If unspecified, instead the 0-based index of the port
+                                in the list is used.
+                              type: string
+                            network:
+                              description: |-
+                                Network is a query for an openstack network that the port will be created or discovered on.
+                                This will fail if the query returns more than one network.
+                              properties:
+                                description:
+                                  type: string
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  type: string
+                                notTagsAny:
+                                  type: string
+                                projectId:
+                                  type: string
+                                tags:
+                                  type: string
+                                tagsAny:
+                                  type: string
+                              type: object
+                            profile:
+                              description: |-
+                                Profile is a set of key-value pairs that are used for binding details.
+                                We intentionally don't expose this as a map[string]string because we only want to enable
+                                the users to set the values of the keys that are known to work in OpenStack Networking API.
+                                See https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                              properties:
+                                ovsHWOffload:
+                                  description: OVSHWOffload enables or disables the
+                                    OVS hardware offload feature.
+                                  type: boolean
+                                trustedVF:
+                                  description: TrustedVF enables or disables the “trusted
+                                    mode” for the VF.
+                                  type: boolean
+                              type: object
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
+                            securityGroupFilters:
+                              description: The names, uuids, filters or any combination
+                                these of the security groups to assign to the instance
+                              items:
+                                properties:
+                                  description:
+                                    type: string
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  notTags:
+                                    type: string
+                                  notTagsAny:
+                                    type: string
+                                  projectId:
+                                    type: string
+                                  tags:
+                                    type: string
+                                  tagsAny:
+                                    type: string
+                                type: object
+                              type: array
+                            tags:
+                              description: |-
+                                Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                                These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            trunk:
+                              description: Enables and disables trunk at port level.
+                                If not provided, openStackMachine.Spec.Trunk is inherited.
+                              type: boolean
+                            valueSpecs:
+                              description: |-
+                                Value specs are extra parameters to include in the API request with OpenStack.
+                                This is an extension point for the API, so what they do and if they are supported,
+                                depends on the specific OpenStack implementation.
+                              items:
+                                description: ValueSpec represents a single value_spec
+                                  key-value pair.
+                                properties:
+                                  key:
+                                    description: Key is the key in the key-value pair.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the key-value pair.
+                                      This is just for identifying the pair and will not be sent to the OpenStack API.
+                                    type: string
+                                  value:
+                                    description: Value is the value in the key-value
+                                      pair.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            vnicType:
+                              description: The virtual network interface card (vNIC)
+                                type that is bound to the neutron port.
+                              type: string
+                          type: object
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      rootVolume:
+                        description: The volume metadata to boot from
+                        properties:
+                          availabilityZone:
+                            type: string
+                          diskSize:
+                            type: integer
+                          volumeType:
+                            type: string
+                        type: object
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the instance
+                        items:
+                          properties:
+                            description:
+                              type: string
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              type: string
+                            notTagsAny:
+                              type: string
+                            projectId:
+                              type: string
+                            tags:
+                              type: string
+                            tagsAny:
+                              type: string
+                          type: object
+                        type: array
+                      serverGroupID:
+                        description: The server group to assign the machine to
+                        type: string
+                      serverMetadata:
+                        additionalProperties:
+                          type: string
+                        description: Metadata mapping. Allows you to create a map
+                          of key value pairs to add to the server instance.
+                        type: object
+                      sshKeyName:
+                        description: The ssh key to inject in the instance
+                        type: string
+                      tags:
+                        description: |-
+                          Machine tags
+                          Requires Nova api 2.52 minimum!
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      trunk:
+                        description: Whether the server instance is created on a trunk
+                          port or not.
+                        type: boolean
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackMachineTemplate is the Schema for the openstackmachinetemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackMachineTemplateSpec defines the desired state of
+              OpenStackMachineTemplate.
+            properties:
+              template:
+                description: OpenStackMachineTemplateResource describes the data needed
+                  to create a OpenStackMachine from a template.
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalBlockDevices:
+                        description: AdditionalBlockDevices is a list of specifications
+                          for additional block devices to attach to the server instance
+                        items:
+                          description: AdditionalBlockDevice is a block device to
+                            attach to the server.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the block device in the context of a machine.
+                                If the block device is a volume, the Cinder volume will be named
+                                as a combination of the machine name and this name.
+                                Also, this name will be used for tagging the block device.
+                                Information about the block device tag can be obtained from the OpenStack
+                                metadata API or the config drive.
+                                Name cannot be 'root', which is reserved for the root volume.
+                              type: string
+                            sizeGiB:
+                              description: SizeGiB is the size of the block device
+                                in gibibytes (GiB).
+                              minimum: 1
+                              type: integer
+                            storage:
+                              description: |-
+                                Storage specifies the storage type of the block device and
+                                additional storage options.
+                              properties:
+                                type:
+                                  description: |-
+                                    Type is the type of block device to create.
+                                    This can be either "Volume" or "Local".
+                                  type: string
+                                volume:
+                                  description: Volume contains additional storage
+                                    options for a volume block device.
+                                  properties:
+                                    availabilityZone:
+                                      description: |-
+                                        AvailabilityZone is the volume availability zone to create the volume
+                                        in. If not specified, the volume will be created without an explicit
+                                        availability zone.
+                                      properties:
+                                        from:
+                                          default: Name
+                                          description: |-
+                                            From specifies where we will obtain the availability zone for the
+                                            volume. The options are "Name" and "Machine". If "Name" is specified
+                                            then the Name field must also be specified. If "Machine" is specified
+                                            the volume will use the value of FailureDomain, if any, from the
+                                            associated Machine.
+                                          enum:
+                                          - Name
+                                          - Machine
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name is the name of a volume availability zone to use. It is required
+                                            if From is "Name". The volume availability zone name may not contain
+                                            spaces.
+                                          minLength: 1
+                                          pattern: ^[^ ]+$
+                                          type: string
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: name is required when from is 'Name'
+                                          or default
+                                        rule: '!has(self.from) || self.from == ''Name''
+                                          ? has(self.name) : !has(self.name)'
+                                    type:
+                                      description: |-
+                                        Type is the Cinder volume type of the volume.
+                                        If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                        will be used.
+                                      type: string
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - sizeGiB
+                          - storage
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      configDrive:
+                        description: Config Drive support
+                        type: boolean
+                      flavor:
+                        description: The flavor reference for the flavor for your
+                          server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
+                        type: string
+                      floatingIPPoolRef:
+                        description: |-
+                          floatingIPPoolRef is a reference to a IPPool that will be assigned
+                          to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
+                          will be assigned to the OpenStackMachine.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      identityRef:
+                        description: |-
+                          IdentityRef is a reference to a secret holding OpenStack credentials
+                          to be used when reconciling this machine. If not specified, the
+                          credentials specified in the cluster will be used.
+                        properties:
+                          cloudName:
+                            description: CloudName specifies the name of the entry
+                              in the clouds.yaml file to use.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of a secret in the same namespace as the resource being provisioned.
+                              The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                              The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                            type: string
+                          region:
+                            description: |-
+                              Region specifies an OpenStack region to use. If specified, it overrides
+                              any value in clouds.yaml. If specified for an OpenStackMachine, its
+                              value will be included in providerID.
+                            type: string
+                        required:
+                        - cloudName
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                            == oldSelf.region
+                      image:
+                        description: |-
+                          The image to use for your server instance.
+                          If the rootVolume is specified, this will be used when creating the root volume.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: |-
+                              Filter describes a query for an image. If specified, the combination
+                              of name and tags must return a single matching image or an error will
+                              be raised.
+                            minProperties: 1
+                            properties:
+                              name:
+                                description: The name of the desired image. If specified,
+                                  the combination of name and tags must return a single
+                                  matching image or an error will be raised.
+                                type: string
+                              tags:
+                                description: The tags associated with the desired
+                                  image. If specified, the combination of name and
+                                  tags must return a single matching image or an error
+                                  will be raised.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the uuid of the image. ID will not
+                              be validated before use.
+                            format: uuid
+                            type: string
+                          imageRef:
+                            description: |-
+                              ImageRef is a reference to an ORC Image in the same namespace as the
+                              referring object.
+                            properties:
+                              name:
+                                description: Name is the name of the referenced resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      ports:
+                        description: |-
+                          Ports to be attached to the server instance. They are created if a port with the given name does not already exist.
+                          If not specified a default port will be added for the default cluster network.
+                        items:
+                          properties:
+                            adminStateUp:
+                              description: AdminStateUp specifies whether the port
+                                should be created in the up (true) or down (false)
+                                state. The default is up.
+                              type: boolean
+                            allowedAddressPairs:
+                              description: |-
+                                AllowedAddressPairs is a list of address pairs which Neutron will
+                                allow the port to send traffic from in addition to the port's
+                                addresses. If not specified, the MAC Address will be the MAC Address
+                                of the port. Depending on the configuration of Neutron, it may be
+                                supported to specify a CIDR instead of a specific IP address.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    description: |-
+                                      IPAddress is the IP address of the allowed address pair. Depending on
+                                      the configuration of Neutron, it may be supported to specify a CIDR
+                                      instead of a specific IP address.
+                                    type: string
+                                  macAddress:
+                                    description: |-
+                                      MACAddress is the MAC address of the allowed address pair. If not
+                                      specified, the MAC address will be the MAC address of the port.
+                                    type: string
+                                required:
+                                - ipAddress
+                                type: object
+                              type: array
+                            description:
+                              description: Description is a human-readable description
+                                for the port.
+                              type: string
+                            disablePortSecurity:
+                              description: |-
+                                DisablePortSecurity enables or disables the port security when set.
+                                When not set, it takes the value of the corresponding field at the network level.
+                              type: boolean
+                            fixedIPs:
+                              description: FixedIPs is a list of pairs of subnet and/or
+                                IP address to assign to the port. If specified, these
+                                must be subnets of the port's network.
+                              items:
+                                properties:
+                                  ipAddress:
+                                    description: |-
+                                      IPAddress is a specific IP address to assign to the port. If Subnet
+                                      is also specified, IPAddress must be a valid IP address in the
+                                      subnet. If Subnet is not specified, IPAddress must be a valid IP
+                                      address in any subnet of the port's network.
+                                    type: string
+                                  subnet:
+                                    description: |-
+                                      Subnet is an openstack subnet query that will return the id of a subnet to create
+                                      the fixed IP of a port in. This query must not return more than one subnet.
+                                    maxProperties: 1
+                                    minProperties: 1
+                                    properties:
+                                      filter:
+                                        description: Filter specifies a filter to
+                                          select the subnet. It must match exactly
+                                          one subnet.
+                                        minProperties: 1
+                                        properties:
+                                          cidr:
+                                            type: string
+                                          description:
+                                            type: string
+                                          gatewayIP:
+                                            type: string
+                                          ipVersion:
+                                            type: integer
+                                          ipv6AddressMode:
+                                            type: string
+                                          ipv6RAMode:
+                                            type: string
+                                          name:
+                                            type: string
+                                          notTags:
+                                            description: |-
+                                              NotTags is a list of tags to filter by. If specified, resources which
+                                              contain all of the given tags will be excluded from the result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          notTagsAny:
+                                            description: |-
+                                              NotTagsAny is a list of tags to filter by. If specified, resources
+                                              which contain any of the given tags will be excluded from the result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          projectID:
+                                            type: string
+                                          tags:
+                                            description: |-
+                                              Tags is a list of tags to filter by. If specified, the resource must
+                                              have all of the tags specified to be included in the result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          tagsAny:
+                                            description: |-
+                                              TagsAny is a list of tags to filter by. If specified, the resource
+                                              must have at least one of the tags specified to be included in the
+                                              result.
+                                            items:
+                                              description: |-
+                                                NeutronTag represents a tag on a Neutron resource.
+                                                It may not be empty and may not contain commas.
+                                              minLength: 1
+                                              pattern: ^[^,]+$
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        type: object
+                                      id:
+                                        description: ID is the uuid of the subnet.
+                                          It will not be validated.
+                                        format: uuid
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            hostID:
+                              description: HostID specifies the ID of the host where
+                                the port resides.
+                              type: string
+                            macAddress:
+                              description: MACAddress specifies the MAC address of
+                                the port. If not specified, the MAC address will be
+                                generated.
+                              type: string
+                            nameSuffix:
+                              description: NameSuffix will be appended to the name
+                                of the port if specified. If unspecified, instead
+                                the 0-based index of the port in the list is used.
+                              type: string
+                            network:
+                              description: |-
+                                Network is a query for an openstack network that the port will be created or discovered on.
+                                This will fail if the query returns more than one network.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                filter:
+                                  description: Filter specifies a filter to select
+                                    an OpenStack network. If provided, cannot be empty.
+                                  minProperties: 1
+                                  properties:
+                                    description:
+                                      type: string
+                                    name:
+                                      type: string
+                                    notTags:
+                                      description: |-
+                                        NotTags is a list of tags to filter by. If specified, resources which
+                                        contain all of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    notTagsAny:
+                                      description: |-
+                                        NotTagsAny is a list of tags to filter by. If specified, resources
+                                        which contain any of the given tags will be excluded from the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    projectID:
+                                      type: string
+                                    tags:
+                                      description: |-
+                                        Tags is a list of tags to filter by. If specified, the resource must
+                                        have all of the tags specified to be included in the result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    tagsAny:
+                                      description: |-
+                                        TagsAny is a list of tags to filter by. If specified, the resource
+                                        must have at least one of the tags specified to be included in the
+                                        result.
+                                      items:
+                                        description: |-
+                                          NeutronTag represents a tag on a Neutron resource.
+                                          It may not be empty and may not contain commas.
+                                        minLength: 1
+                                        pattern: ^[^,]+$
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  type: object
+                                id:
+                                  description: ID is the ID of the network to use.
+                                    If ID is provided, the other filters cannot be
+                                    provided. Must be in UUID format.
+                                  format: uuid
+                                  type: string
+                              type: object
+                            profile:
+                              description: |-
+                                Profile is a set of key-value pairs that are used for binding
+                                details. We intentionally don't expose this as a map[string]string
+                                because we only want to enable the users to set the values of the
+                                keys that are known to work in OpenStack Networking API.  See
+                                https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                                To set profiles, your tenant needs permissions rule:create_port, and
+                                rule:create_port:binding:profile
+                              properties:
+                                ovsHWOffload:
+                                  description: |-
+                                    OVSHWOffload enables or disables the OVS hardware offload feature.
+                                    This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                                    See: https://bugs.launchpad.net/nova/+bug/2020813
+                                  type: boolean
+                                trustedVF:
+                                  description: TrustedVF enables or disables the “trusted
+                                    mode” for the VF.
+                                  type: boolean
+                              type: object
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
+                            securityGroups:
+                              description: SecurityGroups is a list of the names,
+                                uuids, filters or any combination these of the security
+                                groups to assign to the instance.
+                              items:
+                                description: SecurityGroupParam specifies an OpenStack
+                                  security group. It may be specified by ID or filter,
+                                  but not both.
+                                maxProperties: 1
+                                minProperties: 1
+                                properties:
+                                  filter:
+                                    description: Filter specifies a query to select
+                                      an OpenStack security group. If provided, cannot
+                                      be empty.
+                                    minProperties: 1
+                                    properties:
+                                      description:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        description: |-
+                                          NotTags is a list of tags to filter by. If specified, resources which
+                                          contain all of the given tags will be excluded from the result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      notTagsAny:
+                                        description: |-
+                                          NotTagsAny is a list of tags to filter by. If specified, resources
+                                          which contain any of the given tags will be excluded from the result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      projectID:
+                                        type: string
+                                      tags:
+                                        description: |-
+                                          Tags is a list of tags to filter by. If specified, the resource must
+                                          have all of the tags specified to be included in the result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      tagsAny:
+                                        description: |-
+                                          TagsAny is a list of tags to filter by. If specified, the resource
+                                          must have at least one of the tags specified to be included in the
+                                          result.
+                                        items:
+                                          description: |-
+                                            NeutronTag represents a tag on a Neutron resource.
+                                            It may not be empty and may not contain commas.
+                                          minLength: 1
+                                          pattern: ^[^,]+$
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  id:
+                                    description: ID is the ID of the security group
+                                      to use. If ID is provided, the other filters
+                                      cannot be provided. Must be in UUID format.
+                                    format: uuid
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            tags:
+                              description: |-
+                                Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                                These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            trunk:
+                              description: |-
+                                Trunk specifies whether trunking is enabled at the port level. If not
+                                provided the value is inherited from the machine, or false for a
+                                bastion host.
+                              type: boolean
+                            valueSpecs:
+                              description: |-
+                                Value specs are extra parameters to include in the API request with OpenStack.
+                                This is an extension point for the API, so what they do and if they are supported,
+                                depends on the specific OpenStack implementation.
+                              items:
+                                description: ValueSpec represents a single value_spec
+                                  key-value pair.
+                                properties:
+                                  key:
+                                    description: Key is the key in the key-value pair.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the key-value pair.
+                                      This is just for identifying the pair and will not be sent to the OpenStack API.
+                                    type: string
+                                  value:
+                                    description: Value is the value in the key-value
+                                      pair.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            vnicType:
+                              description: |-
+                                VNICType specifies the type of vNIC which this port should be
+                                attached to. This is used to determine which mechanism driver(s) to
+                                be used to bind the port. The valid values are normal, macvtap,
+                                direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                                remote-managed, although these values will not be validated in this
+                                API to ensure compatibility with future neutron changes or custom
+                                implementations. What type of vNIC is actually available depends on
+                                deployments. If not specified, the Neutron default value is used.
+                              type: string
+                          type: object
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      rootVolume:
+                        description: The volume metadata to boot from
+                        properties:
+                          availabilityZone:
+                            description: |-
+                              AvailabilityZone is the volume availability zone to create the volume
+                              in. If not specified, the volume will be created without an explicit
+                              availability zone.
+                            properties:
+                              from:
+                                default: Name
+                                description: |-
+                                  From specifies where we will obtain the availability zone for the
+                                  volume. The options are "Name" and "Machine". If "Name" is specified
+                                  then the Name field must also be specified. If "Machine" is specified
+                                  the volume will use the value of FailureDomain, if any, from the
+                                  associated Machine.
+                                enum:
+                                - Name
+                                - Machine
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of a volume availability zone to use. It is required
+                                  if From is "Name". The volume availability zone name may not contain
+                                  spaces.
+                                minLength: 1
+                                pattern: ^[^ ]+$
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: name is required when from is 'Name' or default
+                              rule: '!has(self.from) || self.from == ''Name'' ? has(self.name)
+                                : !has(self.name)'
+                          sizeGiB:
+                            description: SizeGiB is the size of the block device in
+                              gibibytes (GiB).
+                            minimum: 1
+                            type: integer
+                          type:
+                            description: |-
+                              Type is the Cinder volume type of the volume.
+                              If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                              will be used.
+                            type: string
+                        required:
+                        - sizeGiB
+                        type: object
+                      schedulerHintAdditionalProperties:
+                        description: |-
+                          SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints
+                          to the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,
+                          such as specifying certain host aggregates or availability zones.
+                        items:
+                          description: |-
+                            SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.
+                            It includes a Name to identify the property and a Value that can be of various types.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the scheduler hint property.
+                                It is a unique identifier for the property.
+                              minLength: 1
+                              type: string
+                            value:
+                              description: |-
+                                Value is the value of the scheduler hint property, which can be of various types
+                                (e.g., bool, string, int). The type is indicated by the Value.Type field.
+                              properties:
+                                bool:
+                                  description: |-
+                                    Bool is the boolean value of the scheduler hint, used when Type is "Bool".
+                                    This field is required if type is 'Bool', and must not be set otherwise.
+                                  type: boolean
+                                number:
+                                  description: |-
+                                    Number is the integer value of the scheduler hint, used when Type is "Number".
+                                    This field is required if type is 'Number', and must not be set otherwise.
+                                  type: integer
+                                string:
+                                  description: |-
+                                    String is the string value of the scheduler hint, used when Type is "String".
+                                    This field is required if type is 'String', and must not be set otherwise.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type represents the type of the value.
+                                    Valid values are Bool, String, and Number.
+                                  enum:
+                                  - Bool
+                                  - String
+                                  - Number
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: bool is required when type is Bool, and forbidden
+                                  otherwise
+                                rule: 'has(self.type) && self.type == ''Bool'' ? has(self.bool)
+                                  : !has(self.bool)'
+                              - message: number is required when type is Number, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Number'' ?
+                                  has(self.number) : !has(self.number)'
+                              - message: string is required when type is String, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''String'' ?
+                                  has(self.string) : !has(self.string)'
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the instance
+                        items:
+                          description: SecurityGroupParam specifies an OpenStack security
+                            group. It may be specified by ID or filter, but not both.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            filter:
+                              description: Filter specifies a query to select an OpenStack
+                                security group. If provided, cannot be empty.
+                              minProperties: 1
+                              properties:
+                                description:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  description: |-
+                                    NotTags is a list of tags to filter by. If specified, resources which
+                                    contain all of the given tags will be excluded from the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                notTagsAny:
+                                  description: |-
+                                    NotTagsAny is a list of tags to filter by. If specified, resources
+                                    which contain any of the given tags will be excluded from the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                projectID:
+                                  type: string
+                                tags:
+                                  description: |-
+                                    Tags is a list of tags to filter by. If specified, the resource must
+                                    have all of the tags specified to be included in the result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                tagsAny:
+                                  description: |-
+                                    TagsAny is a list of tags to filter by. If specified, the resource
+                                    must have at least one of the tags specified to be included in the
+                                    result.
+                                  items:
+                                    description: |-
+                                      NeutronTag represents a tag on a Neutron resource.
+                                      It may not be empty and may not contain commas.
+                                    minLength: 1
+                                    pattern: ^[^,]+$
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                            id:
+                              description: ID is the ID of the security group to use.
+                                If ID is provided, the other filters cannot be provided.
+                                Must be in UUID format.
+                              format: uuid
+                              type: string
+                          type: object
+                        type: array
+                      serverGroup:
+                        description: The server group to assign the machine to.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a query to select an OpenStack
+                              server group. If provided, it cannot be empty.
+                            minProperties: 1
+                            properties:
+                              name:
+                                description: Name is the name of a server group to
+                                  look for.
+                                type: string
+                            type: object
+                          id:
+                            description: ID is the ID of the server group to use.
+                            format: uuid
+                            type: string
+                        type: object
+                      serverMetadata:
+                        description: Metadata mapping. Allows you to create a map
+                          of key value pairs to add to the server instance.
+                        items:
+                          properties:
+                            key:
+                              description: Key is the server metadata key
+                              maxLength: 255
+                              type: string
+                            value:
+                              description: Value is the server metadata value
+                              maxLength: 255
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      sshKeyName:
+                        description: The ssh key to inject in the instance
+                        type: string
+                      tags:
+                        description: |-
+                          Tags which will be added to the machine and all dependent resources
+                          which support them. These are in addition to Tags defined on the
+                          cluster.
+                          Requires Nova api 2.52 minimum!
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      trunk:
+                        description: Whether the server instance is created on a trunk
+                          port or not.
+                        type: boolean
+                    required:
+                    - image
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of flavor or flavorID must be set
+                      rule: (has(self.flavor) || has(self.flavorID))
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    cluster.x-k8s.io/v1beta1: v1alpha7_v1beta1
+  name: openstackservers.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OpenStackServer
+    listKind: OpenStackServerList
+    plural: openstackservers
+    shortNames:
+    - oss
+    singular: openstackserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: OpenStack instance state
+      jsonPath: .status.instanceState
+      name: InstanceState
+      type: string
+    - description: OpenStack instance ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: OpenStack instance ID
+      jsonPath: .status.instanceID
+      name: InstanceID
+      type: string
+    - description: Time duration since creation of OpenStack instance
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackServer is the Schema for the openstackservers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackServerSpec defines the desired state of OpenStackServer.
+            properties:
+              additionalBlockDevices:
+                description: AdditionalBlockDevices is a list of specifications for
+                  additional block devices to attach to the server instance.
+                items:
+                  description: AdditionalBlockDevice is a block device to attach to
+                    the server.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the block device in the context of a machine.
+                        If the block device is a volume, the Cinder volume will be named
+                        as a combination of the machine name and this name.
+                        Also, this name will be used for tagging the block device.
+                        Information about the block device tag can be obtained from the OpenStack
+                        metadata API or the config drive.
+                        Name cannot be 'root', which is reserved for the root volume.
+                      type: string
+                    sizeGiB:
+                      description: SizeGiB is the size of the block device in gibibytes
+                        (GiB).
+                      minimum: 1
+                      type: integer
+                    storage:
+                      description: |-
+                        Storage specifies the storage type of the block device and
+                        additional storage options.
+                      properties:
+                        type:
+                          description: |-
+                            Type is the type of block device to create.
+                            This can be either "Volume" or "Local".
+                          type: string
+                        volume:
+                          description: Volume contains additional storage options
+                            for a volume block device.
+                          properties:
+                            availabilityZone:
+                              description: |-
+                                AvailabilityZone is the volume availability zone to create the volume
+                                in. If not specified, the volume will be created without an explicit
+                                availability zone.
+                              properties:
+                                from:
+                                  default: Name
+                                  description: |-
+                                    From specifies where we will obtain the availability zone for the
+                                    volume. The options are "Name" and "Machine". If "Name" is specified
+                                    then the Name field must also be specified. If "Machine" is specified
+                                    the volume will use the value of FailureDomain, if any, from the
+                                    associated Machine.
+                                  enum:
+                                  - Name
+                                  - Machine
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name is the name of a volume availability zone to use. It is required
+                                    if From is "Name". The volume availability zone name may not contain
+                                    spaces.
+                                  minLength: 1
+                                  pattern: ^[^ ]+$
+                                  type: string
+                              type: object
+                              x-kubernetes-validations:
+                              - message: name is required when from is 'Name' or default
+                                rule: '!has(self.from) || self.from == ''Name'' ?
+                                  has(self.name) : !has(self.name)'
+                            type:
+                              description: |-
+                                Type is the Cinder volume type of the volume.
+                                If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                                will be used.
+                              type: string
+                          type: object
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - name
+                  - sizeGiB
+                  - storage
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              availabilityZone:
+                description: AvailabilityZone is the availability zone in which to
+                  create the server instance.
+                type: string
+              configDrive:
+                description: ConfigDrive is a flag to enable config drive for the
+                  server instance.
+                type: boolean
+              flavor:
+                description: The flavor reference for the flavor for the server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
+                type: string
+              floatingIPPoolRef:
+                description: FloatingIPPoolRef is a reference to a FloatingIPPool
+                  to allocate a floating IP from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              identityRef:
+                description: IdentityRef is a reference to a secret holding OpenStack
+                  credentials.
+                properties:
+                  cloudName:
+                    description: CloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
+                required:
+                - cloudName
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
+              image:
+                description: The image to use for the server instance.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      Filter describes a query for an image. If specified, the combination
+                      of name and tags must return a single matching image or an error will
+                      be raised.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: The name of the desired image. If specified,
+                          the combination of name and tags must return a single matching
+                          image or an error will be raised.
+                        type: string
+                      tags:
+                        description: The tags associated with the desired image. If
+                          specified, the combination of name and tags must return
+                          a single matching image or an error will be raised.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the uuid of the image. ID will not be validated
+                      before use.
+                    format: uuid
+                    type: string
+                  imageRef:
+                    description: |-
+                      ImageRef is a reference to an ORC Image in the same namespace as the
+                      referring object.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced resource
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              ports:
+                description: Ports to be attached to the server instance.
+                items:
+                  properties:
+                    adminStateUp:
+                      description: AdminStateUp specifies whether the port should
+                        be created in the up (true) or down (false) state. The default
+                        is up.
+                      type: boolean
+                    allowedAddressPairs:
+                      description: |-
+                        AllowedAddressPairs is a list of address pairs which Neutron will
+                        allow the port to send traffic from in addition to the port's
+                        addresses. If not specified, the MAC Address will be the MAC Address
+                        of the port. Depending on the configuration of Neutron, it may be
+                        supported to specify a CIDR instead of a specific IP address.
+                      items:
+                        properties:
+                          ipAddress:
+                            description: |-
+                              IPAddress is the IP address of the allowed address pair. Depending on
+                              the configuration of Neutron, it may be supported to specify a CIDR
+                              instead of a specific IP address.
+                            type: string
+                          macAddress:
+                            description: |-
+                              MACAddress is the MAC address of the allowed address pair. If not
+                              specified, the MAC address will be the MAC address of the port.
+                            type: string
+                        required:
+                        - ipAddress
+                        type: object
+                      type: array
+                    description:
+                      description: Description is a human-readable description for
+                        the port.
+                      type: string
+                    disablePortSecurity:
+                      description: |-
+                        DisablePortSecurity enables or disables the port security when set.
+                        When not set, it takes the value of the corresponding field at the network level.
+                      type: boolean
+                    fixedIPs:
+                      description: FixedIPs is a list of pairs of subnet and/or IP
+                        address to assign to the port. If specified, these must be
+                        subnets of the port's network.
+                      items:
+                        properties:
+                          ipAddress:
+                            description: |-
+                              IPAddress is a specific IP address to assign to the port. If Subnet
+                              is also specified, IPAddress must be a valid IP address in the
+                              subnet. If Subnet is not specified, IPAddress must be a valid IP
+                              address in any subnet of the port's network.
+                            type: string
+                          subnet:
+                            description: |-
+                              Subnet is an openstack subnet query that will return the id of a subnet to create
+                              the fixed IP of a port in. This query must not return more than one subnet.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              filter:
+                                description: Filter specifies a filter to select the
+                                  subnet. It must match exactly one subnet.
+                                minProperties: 1
+                                properties:
+                                  cidr:
+                                    type: string
+                                  description:
+                                    type: string
+                                  gatewayIP:
+                                    type: string
+                                  ipVersion:
+                                    type: integer
+                                  ipv6AddressMode:
+                                    type: string
+                                  ipv6RAMode:
+                                    type: string
+                                  name:
+                                    type: string
+                                  notTags:
+                                    description: |-
+                                      NotTags is a list of tags to filter by. If specified, resources which
+                                      contain all of the given tags will be excluded from the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  notTagsAny:
+                                    description: |-
+                                      NotTagsAny is a list of tags to filter by. If specified, resources
+                                      which contain any of the given tags will be excluded from the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  projectID:
+                                    type: string
+                                  tags:
+                                    description: |-
+                                      Tags is a list of tags to filter by. If specified, the resource must
+                                      have all of the tags specified to be included in the result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  tagsAny:
+                                    description: |-
+                                      TagsAny is a list of tags to filter by. If specified, the resource
+                                      must have at least one of the tags specified to be included in the
+                                      result.
+                                    items:
+                                      description: |-
+                                        NeutronTag represents a tag on a Neutron resource.
+                                        It may not be empty and may not contain commas.
+                                      minLength: 1
+                                      pattern: ^[^,]+$
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                type: object
+                              id:
+                                description: ID is the uuid of the subnet. It will
+                                  not be validated.
+                                format: uuid
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    hostID:
+                      description: HostID specifies the ID of the host where the port
+                        resides.
+                      type: string
+                    macAddress:
+                      description: MACAddress specifies the MAC address of the port.
+                        If not specified, the MAC address will be generated.
+                      type: string
+                    nameSuffix:
+                      description: NameSuffix will be appended to the name of the
+                        port if specified. If unspecified, instead the 0-based index
+                        of the port in the list is used.
+                      type: string
+                    network:
+                      description: |-
+                        Network is a query for an openstack network that the port will be created or discovered on.
+                        This will fail if the query returns more than one network.
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        filter:
+                          description: Filter specifies a filter to select an OpenStack
+                            network. If provided, cannot be empty.
+                          minProperties: 1
+                          properties:
+                            description:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              description: |-
+                                NotTags is a list of tags to filter by. If specified, resources which
+                                contain all of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            notTagsAny:
+                              description: |-
+                                NotTagsAny is a list of tags to filter by. If specified, resources
+                                which contain any of the given tags will be excluded from the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            projectID:
+                              type: string
+                            tags:
+                              description: |-
+                                Tags is a list of tags to filter by. If specified, the resource must
+                                have all of the tags specified to be included in the result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            tagsAny:
+                              description: |-
+                                TagsAny is a list of tags to filter by. If specified, the resource
+                                must have at least one of the tags specified to be included in the
+                                result.
+                              items:
+                                description: |-
+                                  NeutronTag represents a tag on a Neutron resource.
+                                  It may not be empty and may not contain commas.
+                                minLength: 1
+                                pattern: ^[^,]+$
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          type: object
+                        id:
+                          description: ID is the ID of the network to use. If ID is
+                            provided, the other filters cannot be provided. Must be
+                            in UUID format.
+                          format: uuid
+                          type: string
+                      type: object
+                    profile:
+                      description: |-
+                        Profile is a set of key-value pairs that are used for binding
+                        details. We intentionally don't expose this as a map[string]string
+                        because we only want to enable the users to set the values of the
+                        keys that are known to work in OpenStack Networking API.  See
+                        https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                        To set profiles, your tenant needs permissions rule:create_port, and
+                        rule:create_port:binding:profile
+                      properties:
+                        ovsHWOffload:
+                          description: |-
+                            OVSHWOffload enables or disables the OVS hardware offload feature.
+                            This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                            See: https://bugs.launchpad.net/nova/+bug/2020813
+                          type: boolean
+                        trustedVF:
+                          description: TrustedVF enables or disables the “trusted
+                            mode” for the VF.
+                          type: boolean
+                      type: object
+                    propagateUplinkStatus:
+                      description: PropageteUplinkStatus enables or disables the propagate
+                        uplink status on the port.
+                      type: boolean
+                    securityGroups:
+                      description: SecurityGroups is a list of the names, uuids, filters
+                        or any combination these of the security groups to assign
+                        to the instance.
+                      items:
+                        description: SecurityGroupParam specifies an OpenStack security
+                          group. It may be specified by ID or filter, but not both.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a query to select an OpenStack
+                              security group. If provided, cannot be empty.
+                            minProperties: 1
+                            properties:
+                              description:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                description: |-
+                                  NotTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the ID of the security group to use.
+                              If ID is provided, the other filters cannot be provided.
+                              Must be in UUID format.
+                            format: uuid
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    tags:
+                      description: |-
+                        Tags applied to the port (and corresponding trunk, if a trunk is configured.)
+                        These tags are applied in addition to the instance's tags, which will also be applied to the port.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    trunk:
+                      description: |-
+                        Trunk specifies whether trunking is enabled at the port level. If not
+                        provided the value is inherited from the machine, or false for a
+                        bastion host.
+                      type: boolean
+                    valueSpecs:
+                      description: |-
+                        Value specs are extra parameters to include in the API request with OpenStack.
+                        This is an extension point for the API, so what they do and if they are supported,
+                        depends on the specific OpenStack implementation.
+                      items:
+                        description: ValueSpec represents a single value_spec key-value
+                          pair.
+                        properties:
+                          key:
+                            description: Key is the key in the key-value pair.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the key-value pair.
+                              This is just for identifying the pair and will not be sent to the OpenStack API.
+                            type: string
+                          value:
+                            description: Value is the value in the key-value pair.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    vnicType:
+                      description: |-
+                        VNICType specifies the type of vNIC which this port should be
+                        attached to. This is used to determine which mechanism driver(s) to
+                        be used to bind the port. The valid values are normal, macvtap,
+                        direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                        remote-managed, although these values will not be validated in this
+                        API to ensure compatibility with future neutron changes or custom
+                        implementations. What type of vNIC is actually available depends on
+                        deployments. If not specified, the Neutron default value is used.
+                      type: string
+                  type: object
+                type: array
+              rootVolume:
+                description: RootVolume is the specification for the root volume of
+                  the server instance.
+                properties:
+                  availabilityZone:
+                    description: |-
+                      AvailabilityZone is the volume availability zone to create the volume
+                      in. If not specified, the volume will be created without an explicit
+                      availability zone.
+                    properties:
+                      from:
+                        default: Name
+                        description: |-
+                          From specifies where we will obtain the availability zone for the
+                          volume. The options are "Name" and "Machine". If "Name" is specified
+                          then the Name field must also be specified. If "Machine" is specified
+                          the volume will use the value of FailureDomain, if any, from the
+                          associated Machine.
+                        enum:
+                        - Name
+                        - Machine
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of a volume availability zone to use. It is required
+                          if From is "Name". The volume availability zone name may not contain
+                          spaces.
+                        minLength: 1
+                        pattern: ^[^ ]+$
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when from is 'Name' or default
+                      rule: '!has(self.from) || self.from == ''Name'' ? has(self.name)
+                        : !has(self.name)'
+                  sizeGiB:
+                    description: SizeGiB is the size of the block device in gibibytes
+                      (GiB).
+                    minimum: 1
+                    type: integer
+                  type:
+                    description: |-
+                      Type is the Cinder volume type of the volume.
+                      If omitted, the default Cinder volume type that is configured in the OpenStack cloud
+                      will be used.
+                    type: string
+                required:
+                - sizeGiB
+                type: object
+              schedulerHintAdditionalProperties:
+                description: |-
+                  SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints
+                  to the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,
+                  such as specifying certain host aggregates or availability zones.
+                items:
+                  description: |-
+                    SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.
+                    It includes a Name to identify the property and a Value that can be of various types.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the scheduler hint property.
+                        It is a unique identifier for the property.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: |-
+                        Value is the value of the scheduler hint property, which can be of various types
+                        (e.g., bool, string, int). The type is indicated by the Value.Type field.
+                      properties:
+                        bool:
+                          description: |-
+                            Bool is the boolean value of the scheduler hint, used when Type is "Bool".
+                            This field is required if type is 'Bool', and must not be set otherwise.
+                          type: boolean
+                        number:
+                          description: |-
+                            Number is the integer value of the scheduler hint, used when Type is "Number".
+                            This field is required if type is 'Number', and must not be set otherwise.
+                          type: integer
+                        string:
+                          description: |-
+                            String is the string value of the scheduler hint, used when Type is "String".
+                            This field is required if type is 'String', and must not be set otherwise.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        type:
+                          description: |-
+                            Type represents the type of the value.
+                            Valid values are Bool, String, and Number.
+                          enum:
+                          - Bool
+                          - String
+                          - Number
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: bool is required when type is Bool, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Bool'' ? has(self.bool)
+                          : !has(self.bool)'
+                      - message: number is required when type is Number, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Number'' ? has(self.number)
+                          : !has(self.number)'
+                      - message: string is required when type is String, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''String'' ? has(self.string)
+                          : !has(self.string)'
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              securityGroups:
+                description: SecurityGroups is a list of security groups names to
+                  assign to the instance.
+                items:
+                  description: SecurityGroupParam specifies an OpenStack security
+                    group. It may be specified by ID or filter, but not both.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: Filter specifies a query to select an OpenStack
+                        security group. If provided, cannot be empty.
+                      minProperties: 1
+                      properties:
+                        description:
+                          type: string
+                        name:
+                          type: string
+                        notTags:
+                          description: |-
+                            NotTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            NotTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        projectID:
+                          type: string
+                        tags:
+                          description: |-
+                            Tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            TagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            minLength: 1
+                            pattern: ^[^,]+$
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: ID is the ID of the security group to use. If ID
+                        is provided, the other filters cannot be provided. Must be
+                        in UUID format.
+                      format: uuid
+                      type: string
+                  type: object
+                type: array
+              serverGroup:
+                description: ServerGroup is the server group to which the server instance
+                  belongs.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a query to select an OpenStack server
+                      group. If provided, it cannot be empty.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: Name is the name of a server group to look for.
+                        type: string
+                    type: object
+                  id:
+                    description: ID is the ID of the server group to use.
+                    format: uuid
+                    type: string
+                type: object
+              serverMetadata:
+                description: ServerMetadata is a map of key value pairs to add to
+                  the server instance.
+                items:
+                  properties:
+                    key:
+                      description: Key is the server metadata key
+                      maxLength: 255
+                      type: string
+                    value:
+                      description: Value is the server metadata value
+                      maxLength: 255
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
+              sshKeyName:
+                description: SSHKeyName is the name of the SSH key to inject in the
+                  instance.
+                type: string
+              tags:
+                description: |-
+                  Tags which will be added to the machine and all dependent resources
+                  which support them. These are in addition to Tags defined on the
+                  cluster.
+                  Requires Nova api 2.52 minimum!
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              trunk:
+                description: Trunk is a flag to indicate if the server instance is
+                  created on a trunk port or not.
+                type: boolean
+              userDataRef:
+                description: |-
+                  UserDataRef is a reference to a secret containing the user data to
+                  be injected into the server instance.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - identityRef
+            - image
+            - ports
+            - sshKeyName
+            type: object
+            x-kubernetes-validations:
+            - message: at least one of flavor or flavorID must be set
+              rule: (has(self.flavor) || has(self.flavorID))
+          status:
+            description: OpenStackServerStatus defines the observed state of OpenStackServer.
+            properties:
+              addresses:
+                description: Addresses is the list of addresses of the server instance.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
+                      type: string
+                    type:
+                      description: Node address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the OpenStackServer.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              instanceID:
+                description: InstanceID is the ID of the server instance.
+                type: string
+              instanceState:
+                description: InstanceState is the state of the server instance.
+                type: string
+              ready:
+                default: false
+                description: Ready is true when the OpenStack server is ready.
+                type: boolean
+              resolved:
+                description: |-
+                  Resolved contains parts of the machine spec with all external
+                  references fully resolved.
+                properties:
+                  flavorID:
+                    description: FlavorID is the ID of the flavor to use.
+                    type: string
+                  imageID:
+                    description: ImageID is the ID of the image to use for the server
+                      and is calculated based on ImageFilter.
+                    type: string
+                  ports:
+                    description: Ports is the fully resolved list of ports to create
+                      for the server.
+                    items:
+                      description: ResolvedPortSpec is a PortOpts with all contained
+                        references fully resolved.
+                      properties:
+                        adminStateUp:
+                          description: AdminStateUp specifies whether the port should
+                            be created in the up (true) or down (false) state. The
+                            default is up.
+                          type: boolean
+                        allowedAddressPairs:
+                          description: |-
+                            AllowedAddressPairs is a list of address pairs which Neutron will
+                            allow the port to send traffic from in addition to the port's
+                            addresses. If not specified, the MAC Address will be the MAC Address
+                            of the port. Depending on the configuration of Neutron, it may be
+                            supported to specify a CIDR instead of a specific IP address.
+                          items:
+                            properties:
+                              ipAddress:
+                                description: |-
+                                  IPAddress is the IP address of the allowed address pair. Depending on
+                                  the configuration of Neutron, it may be supported to specify a CIDR
+                                  instead of a specific IP address.
+                                type: string
+                              macAddress:
+                                description: |-
+                                  MACAddress is the MAC address of the allowed address pair. If not
+                                  specified, the MAC address will be the MAC address of the port.
+                                type: string
+                            required:
+                            - ipAddress
+                            type: object
+                          type: array
+                        description:
+                          description: Description is a human-readable description
+                            for the port.
+                          type: string
+                        disablePortSecurity:
+                          description: |-
+                            DisablePortSecurity enables or disables the port security when set.
+                            When not set, it takes the value of the corresponding field at the network level.
+                          type: boolean
+                        fixedIPs:
+                          description: FixedIPs is a list of pairs of subnet and/or
+                            IP address to assign to the port. If specified, these
+                            must be subnets of the port's network.
+                          items:
+                            description: ResolvedFixedIP is a FixedIP with the Subnet
+                              resolved to an ID.
+                            properties:
+                              ipAddress:
+                                description: |-
+                                  IPAddress is a specific IP address to assign to the port. If SubnetID
+                                  is also specified, IPAddress must be a valid IP address in the
+                                  subnet. If Subnet is not specified, IPAddress must be a valid IP
+                                  address in any subnet of the port's network.
+                                type: string
+                              subnet:
+                                description: SubnetID is the id of a subnet to create
+                                  the fixed IP of a port in.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        hostID:
+                          description: HostID specifies the ID of the host where the
+                            port resides.
+                          type: string
+                        macAddress:
+                          description: MACAddress specifies the MAC address of the
+                            port. If not specified, the MAC address will be generated.
+                          type: string
+                        name:
+                          description: Name is the name of the port.
+                          type: string
+                        networkID:
+                          description: NetworkID is the ID of the network the port
+                            will be created in.
+                          type: string
+                        profile:
+                          description: |-
+                            Profile is a set of key-value pairs that are used for binding
+                            details. We intentionally don't expose this as a map[string]string
+                            because we only want to enable the users to set the values of the
+                            keys that are known to work in OpenStack Networking API.  See
+                            https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port
+                            To set profiles, your tenant needs permissions rule:create_port, and
+                            rule:create_port:binding:profile
+                          properties:
+                            ovsHWOffload:
+                              description: |-
+                                OVSHWOffload enables or disables the OVS hardware offload feature.
+                                This flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.
+                                See: https://bugs.launchpad.net/nova/+bug/2020813
+                              type: boolean
+                            trustedVF:
+                              description: TrustedVF enables or disables the “trusted
+                                mode” for the VF.
+                              type: boolean
+                          type: object
+                        propagateUplinkStatus:
+                          description: PropageteUplinkStatus enables or disables the
+                            propagate uplink status on the port.
+                          type: boolean
+                        securityGroups:
+                          description: SecurityGroups is a list of security group
+                            IDs to assign to the port.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        tags:
+                          description: Tags applied to the port (and corresponding
+                            trunk, if a trunk is configured.)
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        trunk:
+                          description: Trunk specifies whether trunking is enabled
+                            at the port level.
+                          type: boolean
+                        valueSpecs:
+                          description: |-
+                            Value specs are extra parameters to include in the API request with OpenStack.
+                            This is an extension point for the API, so what they do and if they are supported,
+                            depends on the specific OpenStack implementation.
+                          items:
+                            description: ValueSpec represents a single value_spec
+                              key-value pair.
+                            properties:
+                              key:
+                                description: Key is the key in the key-value pair.
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of the key-value pair.
+                                  This is just for identifying the pair and will not be sent to the OpenStack API.
+                                type: string
+                              value:
+                                description: Value is the value in the key-value pair.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        vnicType:
+                          description: |-
+                            VNICType specifies the type of vNIC which this port should be
+                            attached to. This is used to determine which mechanism driver(s) to
+                            be used to bind the port. The valid values are normal, macvtap,
+                            direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                            remote-managed, although these values will not be validated in this
+                            API to ensure compatibility with future neutron changes or custom
+                            implementations. What type of vNIC is actually available depends on
+                            deployments. If not specified, the Neutron default value is used.
+                          type: string
+                      required:
+                      - description
+                      - name
+                      - networkID
+                      type: object
+                    type: array
+                  serverGroupID:
+                    description: ServerGroupID is the ID of the server group the server
+                      should be added to and is calculated based on ServerGroupFilter.
+                    type: string
+                type: object
+              resources:
+                description: Resources contains references to OpenStack resources
+                  created for the machine.
+                properties:
+                  ports:
+                    description: Ports is the status of the ports created for the
+                      server.
+                    items:
+                      properties:
+                        id:
+                          description: ID is the unique identifier of the port.
+                          type: string
+                      required:
+                      - id
+                      type: object
+                    type: array
+                type: object
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-manager
+  namespace: capo-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-leader-election-role
+  namespace: capo-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - openstackclusters
+  - openstackfloatingippools
+  - openstackmachines
+  - openstackservers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - openstackclusters/status
+  - openstackfloatingippools/status
+  - openstackmachines/status
+  - openstackservers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims
+  - ipaddressclaims/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddresses
+  - ipaddresses/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-leader-election-rolebinding
+  namespace: capo-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capo-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capo-manager
+  namespace: capo-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capo-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capo-manager
+  namespace: capo-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-webhook-service
+  namespace: capo-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+    control-plane: capo-controller-manager
+  name: capo-controller-manager
+  namespace: capo-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: infrastructure-openstack
+      control-plane: capo-controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: infrastructure-openstack
+        control-plane: capo-controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --v=2
+        - --diagnostics-address=127.0.0.1:8080
+        - --insecure-diagnostics=true
+        command:
+        - /manager
+        image: registry.k8s.io/capi-openstack/capi-openstack-controller:v0.12.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: capo-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: capo-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-serving-cert
+  namespace: capo-system
+spec:
+  dnsNames:
+  - capo-webhook-service.capo-system.svc
+  - capo-webhook-service.capo-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capo-selfsigned-issuer
+  secretName: capo-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-selfsigned-issuer
+  namespace: capo-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capo-system/capo-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
+  name: capo-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capo-webhook-service
+      namespace: capo-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-openstackcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.openstackcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capo-webhook-service
+      namespace: capo-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-openstackclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.openstackclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capo-webhook-service
+      namespace: capo-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-openstackmachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.openstackmachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackmachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capo-webhook-service
+      namespace: capo-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-openstackmachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.openstackmachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackmachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capo-webhook-service
+      namespace: capo-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-openstackserver
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.openstackserver.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackservers
+  sideEffects: None

--- a/roles/cluster_api/files/providers/infrastructure-openstack/v0.12.2/metadata.yaml
+++ b/roles/cluster_api/files/providers/infrastructure-openstack/v0.12.2/metadata.yaml
@@ -1,0 +1,27 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 5
+  contract: v1beta1
+- major: 0
+  minor: 6
+  contract: v1beta1
+- major: 0
+  minor: 7
+  contract: v1beta1
+- major: 0
+  minor: 8
+  contract: v1beta1
+- major: 0
+  minor: 9
+  contract: v1beta1
+- major: 0
+  minor: 10
+  contract: v1beta1
+- major: 0
+  minor: 11
+  contract: v1beta1
+- major: 0
+  minor: 12
+  contract: v1beta1

--- a/roles/cluster_api/tasks/patch.yml
+++ b/roles/cluster_api/tasks/patch.yml
@@ -24,6 +24,20 @@
     - namespace: capo-system
       name: capo-controller-manager
 
+- name: Install required controllers
+  kubernetes.core.k8s:
+    state: present
+    template:
+      - path: "controllers/{{ cluster_api_infrastructure_provider }}-resource-controller/install.yaml.j2"
+    apply: true
+    server_side_apply:
+      field_manager: ansible
+      force_conflicts: true
+  run_once: true
+  when:
+    - cluster_api_infrastructure_provider == "openstack"
+    - cluster_api_infrastructure_version is ansible.builtin.version('0.12.0', 'ge')
+
 # Note(okozachenko1203): Until https://github.com/kubernetes-sigs/cluster-api/issues/9132 is fixed,
 #                        set the default value of imagePullPolicy in CRDs.
 # yamllint disable rule:line-length

--- a/roles/cluster_api/templates/controllers/openstack-resource-controller/install.yaml.j2
+++ b/roles/cluster_api/templates/controllers/openstack-resource-controller/install.yaml.j2
@@ -1,0 +1,4667 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: flavors.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Flavor
+    listKind: FlavorList
+    plural: flavors
+    singular: flavor
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Flavor is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      disk:
+                        description: disk is the size of the root disk in GiB.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      ram:
+                        description: ram is the memory of the flavor, measured in
+                          MB.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      vcpus:
+                        description: vcpus is the number of vcpus for the flavor.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  description:
+                    description: description contains a free form description of the
+                      flavor.
+                    maxLength: 65535
+                    minLength: 1
+                    type: string
+                  disk:
+                    description: |-
+                      disk is the size of the root disk that will be created in GiB. If 0
+                      the root disk will be set to exactly the size of the image used to
+                      deploy the instance. However, in this case the scheduler cannot
+                      select the compute host based on the virtual image size. Therefore,
+                      0 should only be used for volume booted instances or for testing
+                      purposes. Volume-backed instances can be enforced for flavors with
+                      zero root disk via the
+                      os_compute_api:servers:create:zero_disk_flavor policy rule.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  ephemeral:
+                    description: |-
+                      ephemeral is the size of the ephemeral disk that will be created, in GiB.
+                      Ephemeral disks may be written over on server state changes. So should only
+                      be used as a scratch space for applications that are aware of its
+                      limitations. Defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  isPublic:
+                    description: isPublic flags a flavor as being available to all
+                      projects or not.
+                    type: boolean
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  ram:
+                    description: ram is the memory of the flavor, measured in MB.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  swap:
+                    description: |-
+                      swap is the size of a dedicated swap disk that will be allocated, in
+                      MiB. If 0 (the default), no dedicated swap disk will be created.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  vcpus:
+                    description: vcpus is the number of vcpus for the flavor.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                required:
+                - disk
+                - ram
+                - vcpus
+                type: object
+                x-kubernetes-validations:
+                - message: FlavorResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 65535
+                    type: string
+                  disk:
+                    description: disk is the size of the root disk that will be created
+                      in GiB.
+                    format: int32
+                    type: integer
+                  ephemeral:
+                    description: ephemeral is the size of the ephemeral disk, in GiB.
+                    format: int32
+                    type: integer
+                  isPublic:
+                    description: isPublic flags a flavor as being available to all
+                      projects or not.
+                    type: boolean
+                  name:
+                    description: name is a Human-readable name for the flavor. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  ram:
+                    description: ram is the memory of the flavor, measured in MB.
+                    format: int32
+                    type: integer
+                  swap:
+                    description: |-
+                      swap is the size of a dedicated swap disk that will be allocated, in
+                      MiB.
+                    format: int32
+                    type: integer
+                  vcpus:
+                    description: vcpus is the number of vcpus for the flavor.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: images.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Image
+    listKind: ImageList
+    plural: images
+    singular: image
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Image is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: name specifies the name of a Glance image
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      tags:
+                        description: tags is the list of tags on the resource.
+                        items:
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  content:
+                    description: content specifies how to obtain the image content.
+                    properties:
+                      containerFormat:
+                        default: bare
+                        description: |-
+                          containerFormat is the format of the image container.
+                          qcow2 and raw images do not usually have a container. This is specified as "bare", which is also the default.
+                          Permitted values are ami, ari, aki, bare, compressed, ovf, ova, and docker.
+                        enum:
+                        - ami
+                        - ari
+                        - aki
+                        - bare
+                        - ovf
+                        - ova
+                        - docker
+                        - compressed
+                        type: string
+                      diskFormat:
+                        description: |-
+                          diskFormat is the format of the disk image.
+                          Normal values are "qcow2", or "raw". Glance may be configured to support others.
+                        enum:
+                        - ami
+                        - ari
+                        - aki
+                        - vhd
+                        - vhdx
+                        - vmdk
+                        - raw
+                        - qcow2
+                        - vdi
+                        - ploop
+                        - iso
+                        type: string
+                      download:
+                        description: |-
+                          download describes how to obtain image data by downloading it from a URL.
+                          Must be set when creating a managed image.
+                        properties:
+                          decompress:
+                            description: |-
+                              decompress specifies that the source data must be decompressed with the
+                              given compression algorithm before being stored. Specifying Decompress
+                              will disable the use of Glance's web-download, as web-download cannot
+                              currently deterministically decompress downloaded content.
+                            enum:
+                            - xz
+                            - gz
+                            - bz2
+                            type: string
+                          hash:
+                            description: |-
+                              hash is a hash which will be used to verify downloaded data, i.e.
+                              before any decompression. If not specified, no hash verification will be
+                              performed. Specifying a Hash will disable the use of Glance's
+                              web-download, as web-download cannot currently deterministically verify
+                              the hash of downloaded content.
+                            properties:
+                              algorithm:
+                                description: algorithm is the hash algorithm used
+                                  to generate value.
+                                enum:
+                                - md5
+                                - sha1
+                                - sha256
+                                - sha512
+                                type: string
+                              value:
+                                description: value is the hash of the image data using
+                                  Algorithm. It must be hex encoded using lowercase
+                                  letters.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[0-9a-f]+$
+                                type: string
+                            required:
+                            - algorithm
+                            - value
+                            type: object
+                            x-kubernetes-validations:
+                            - message: hash is immutable
+                              rule: self == oldSelf
+                          url:
+                            description: url containing image data
+                            format: uri
+                            maxLength: 2048
+                            type: string
+                        required:
+                        - url
+                        type: object
+                    required:
+                    - diskFormat
+                    - download
+                    type: object
+                    x-kubernetes-validations:
+                    - message: content is immutable
+                      rule: self == oldSelf
+                  name:
+                    description: |-
+                      name will be the name of the created Glance image. If not specified, the
+                      name of the Image object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  properties:
+                    description: properties is metadata available to consumers of
+                      the image
+                    properties:
+                      hardware:
+                        description: |-
+                          hardware is a set of properties which control the virtual hardware
+                          created by Nova.
+                        properties:
+                          cdromBus:
+                            description: cdromBus specifies the type of disk controller
+                              to attach CD-ROM devices to.
+                            enum:
+                            - scsi
+                            - virtio
+                            - uml
+                            - xen
+                            - ide
+                            - usb
+                            - lxc
+                            type: string
+                          cpuCores:
+                            description: cpuCores is the preferred number of cores
+                              to expose to the guest
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          cpuPolicy:
+                            description: |-
+                              cpuPolicy is used to pin the virtual CPUs (vCPUs) of instances to the
+                              host's physical CPU cores (pCPUs). Host aggregates should be used to
+                              separate these pinned instances from unpinned instances as the latter
+                              will not respect the resourcing requirements of the former.
+
+                              Permitted values are shared (the default), and dedicated.
+
+                              shared: The guest vCPUs will be allowed to freely float across host
+                              pCPUs, albeit potentially constrained by NUMA policy.
+
+                              dedicated: The guest vCPUs will be strictly pinned to a set of host
+                              pCPUs. In the absence of an explicit vCPU topology request, the
+                              drivers typically expose all vCPUs as sockets with one core and one
+                              thread. When strict CPU pinning is in effect the guest CPU topology
+                              will be setup to match the topology of the CPUs to which it is
+                              pinned. This option implies an overcommit ratio of 1.0. For example,
+                              if a two vCPU guest is pinned to a single host core with two threads,
+                              then the guest will get a topology of one socket, one core, two
+                              threads.
+                            enum:
+                            - shared
+                            - dedicated
+                            type: string
+                          cpuSockets:
+                            description: cpuSockets is the preferred number of sockets
+                              to expose to the guest
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          cpuThreadPolicy:
+                            description: |-
+                              cpuThreadPolicy further refines a CPUPolicy of 'dedicated' by stating
+                              how hardware CPU threads in a simultaneous multithreading-based (SMT)
+                              architecture be used. SMT-based architectures include Intel
+                              processors with Hyper-Threading technology. In these architectures,
+                              processor cores share a number of components with one or more other
+                              cores. Cores in such architectures are commonly referred to as
+                              hardware threads, while the cores that a given core share components
+                              with are known as thread siblings.
+
+                              Permitted values are prefer (the default), isolate, and require.
+
+                              prefer: The host may or may not have an SMT architecture. Where an
+                              SMT architecture is present, thread siblings are preferred.
+
+                              isolate: The host must not have an SMT architecture or must emulate a
+                              non-SMT architecture. If the host does not have an SMT architecture,
+                              each vCPU is placed on a different core as expected. If the host does
+                              have an SMT architecture - that is, one or more cores have thread
+                              siblings - then each vCPU is placed on a different physical core. No
+                              vCPUs from other guests are placed on the same core. All but one
+                              thread sibling on each utilized core is therefore guaranteed to be
+                              unusable.
+
+                              require: The host must have an SMT architecture. Each vCPU is
+                              allocated on thread siblings. If the host does not have an SMT
+                              architecture, then it is not used. If the host has an SMT
+                              architecture, but not enough cores with free thread siblings are
+                              available, then scheduling fails.
+                            enum:
+                            - prefer
+                            - isolate
+                            - require
+                            type: string
+                          cpuThreads:
+                            description: cpuThreads is the preferred number of threads
+                              to expose to the guest
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          diskBus:
+                            description: diskBus specifies the type of disk controller
+                              to attach disk devices to.
+                            enum:
+                            - scsi
+                            - virtio
+                            - uml
+                            - xen
+                            - ide
+                            - usb
+                            - lxc
+                            type: string
+                          scsiModel:
+                            description: |-
+                              scsiModel enables the use of VirtIO SCSI (virtio-scsi) to provide
+                              block device access for compute instances; by default, instances use
+                              VirtIO Block (virtio-blk). VirtIO SCSI is a para-virtualized SCSI
+                              controller device that provides improved scalability and performance,
+                              and supports advanced SCSI hardware.
+
+                              The only permitted value is virtio-scsi.
+                            enum:
+                            - virtio-scsi
+                            type: string
+                          vifModel:
+                            description: |-
+                              vifModel specifies the model of virtual network interface device to use.
+
+                              Permitted values are e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio,
+                              and vmxnet3.
+                            enum:
+                            - e1000
+                            - e1000e
+                            - ne2k_pci
+                            - pcnet
+                            - rtl8139
+                            - virtio
+                            - vmxnet3
+                            type: string
+                        type: object
+                      minDiskGB:
+                        description: minDiskGB is the minimum amount of disk space
+                          in GB that is required to boot the image
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      minMemoryMB:
+                        description: minMemoryMB is the minimum amount of RAM in MB
+                          that is required to boot the image.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  protected:
+                    description: |-
+                      protected specifies that the image is protected from deletion.
+                      If not specified, the default is false.
+                    type: boolean
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      image. A tag has a maximum length of 255 characters.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  visibility:
+                    description: visibility of the image
+                    enum:
+                    - public
+                    - private
+                    - shared
+                    - community
+                    type: string
+                    x-kubernetes-validations:
+                    - message: visibility is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: name is immutable
+                  rule: 'has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)'
+                - message: name is immutable
+                  rule: 'has(self.protected) ? self.protected == oldSelf.protected
+                    : !has(oldSelf.protected)'
+                - message: tags is immutable
+                  rule: 'has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)'
+                - message: visibility is immutable
+                  rule: 'has(self.visibility) ? self.visibility == oldSelf.visibility
+                    : !has(oldSelf.visibility)'
+                - message: properties is immutable
+                  rule: 'has(self.properties) ? self.properties == oldSelf.properties
+                    : !has(oldSelf.properties)'
+                - message: ImageResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+            - message: resource content must be specified when not importing
+              rule: '!has(self.__import__) ? has(self.resource.content) : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              downloadAttempts:
+                description: downloadAttempts is the number of times the controller
+                  has attempted to download the image contents
+                format: int32
+                type: integer
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  hash:
+                    description: |-
+                      hash is the hash of the image data published by Glance. Note that this is
+                      a hash of the data stored internally by Glance, which will have been
+                      decompressed and potentially format converted depending on server-side
+                      configuration which is not visible to clients. It is expected that this
+                      hash will usually differ from the download hash.
+                    properties:
+                      algorithm:
+                        description: algorithm is the hash algorithm used to generate
+                          value.
+                        enum:
+                        - md5
+                        - sha1
+                        - sha256
+                        - sha512
+                        type: string
+                      value:
+                        description: value is the hash of the image data using Algorithm.
+                          It must be hex encoded using lowercase letters.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[0-9a-f]+$
+                        type: string
+                    required:
+                    - algorithm
+                    - value
+                    type: object
+                  name:
+                    description: name is a Human-readable name for the image. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  protected:
+                    description: protected specifies that the image is protected from
+                      deletion.
+                    type: boolean
+                  sizeB:
+                    description: sizeB is the size of the image data, in bytes
+                    format: int64
+                    type: integer
+                  status:
+                    description: status is the image status as reported by Glance
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  virtualSizeB:
+                    description: virtualSizeB is the size of the disk the image data
+                      represents, in bytes
+                    format: int64
+                    type: integer
+                  visibility:
+                    description: visibility of the image
+                    maxLength: 1024
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: networks.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Network is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      external:
+                        description: |-
+                          external indicates whether the network has an external routing
+                          facility that’s not managed by the networking service.
+                        type: boolean
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  adminStateUp:
+                    description: adminStateUp is the administrative state of the network,
+                      which is up (true) or down (false)
+                    type: boolean
+                  availabilityZoneHints:
+                    description: availabilityZoneHints is the availability zone candidate
+                      for the network.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  dnsDomain:
+                    description: dnsDomain is the DNS domain of the network
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[A-Za-z0-9]{1,63}(.[A-Za-z0-9-]{1,63})*(.[A-Za-z]{2,63})*.?$
+                    type: string
+                  external:
+                    description: |-
+                      external indicates whether the network has an external routing
+                      facility that’s not managed by the networking service.
+                    type: boolean
+                  mtu:
+                    description: |-
+                      mtu is the the maximum transmission unit value to address
+                      fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
+                      Defaults to 1500.
+                    format: int32
+                    maximum: 9216
+                    minimum: 68
+                    type: integer
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  portSecurityEnabled:
+                    description: |-
+                      portSecurityEnabled is the port security status of the network.
+                      Valid values are enabled (true) and disabled (false). This value is
+                      used as the default value of port_security_enabled field of a newly
+                      created port.
+                    type: boolean
+                  shared:
+                    description: |-
+                      shared indicates whether this resource is shared across all
+                      projects. By default, only administrative users can change this
+                      value.
+                    type: boolean
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      network.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 64
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+                x-kubernetes-validations:
+                - message: NetworkResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp is the administrative state of the network,
+                      which is up (true) or down (false).
+                    type: boolean
+                  availabilityZoneHints:
+                    description: |-
+                      availabilityZoneHints is the availability zone candidate for the
+                      network.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  dnsDomain:
+                    description: dnsDomain is the DNS domain of the network
+                    maxLength: 1024
+                    type: string
+                  external:
+                    description: |-
+                      external defines whether the network may be used for creation of
+                      floating IPs. Only networks with this flag may be an external
+                      gateway for routers. The network must have an external routing
+                      facility that is not managed by the networking service. If the
+                      network is updated from external to internal the unused floating IPs
+                      of this network are automatically deleted when extension
+                      floatingip-autodelete-internal is present.
+                    type: boolean
+                  mtu:
+                    description: |-
+                      mtu is the the maximum transmission unit value to address
+                      fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
+                    format: int32
+                    type: integer
+                  name:
+                    description: name is a Human-readable name for the network. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  portSecurityEnabled:
+                    description: |-
+                      portSecurityEnabled is the port security status of the network.
+                      Valid values are enabled (true) and disabled (false). This value is
+                      used as the default value of port_security_enabled field of a newly
+                      created port.
+                    type: boolean
+                  projectID:
+                    description: projectID is the project owner of the network.
+                    maxLength: 1024
+                    type: string
+                  provider:
+                    description: provider contains provider-network properties.
+                    properties:
+                      networkType:
+                        description: |-
+                          networkType is the type of physical network that this
+                          network should be mapped to. Supported values are flat, vlan, vxlan, and gre.
+                          Valid values depend on the networking back-end.
+                        maxLength: 1024
+                        type: string
+                      physicalNetwork:
+                        description: |-
+                          physicalNetwork is the physical network where this network
+                          should be implemented. The Networking API v2.0 does not provide a
+                          way to list available physical networks. For example, the Open
+                          vSwitch plug-in configuration file defines a symbolic name that maps
+                          to specific bridges on each compute host.
+                        maxLength: 1024
+                        type: string
+                      segmentationID:
+                        description: |-
+                          segmentationID is the ID of the isolated segment on the
+                          physical network. The network_type attribute defines the
+                          segmentation model. For example, if the network_type value is vlan,
+                          this ID is a vlan identifier. If the network_type value is gre, this
+                          ID is a gre key.
+                        format: int32
+                        type: integer
+                    type: object
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  shared:
+                    description: |-
+                      shared specifies whether the network resource can be accessed by any
+                      tenant.
+                    type: boolean
+                  status:
+                    description: |-
+                      status indicates whether network is currently operational. Possible values
+                      include `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define
+                      additional values.
+                    maxLength: 1024
+                    type: string
+                  subnets:
+                    description: subnets associated with this network.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: ports.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Port
+    listKind: PortList
+    plural: ports
+    singular: port
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Allocated IP addresses
+      jsonPath: .status.resource.fixedIPs[*].ip
+      name: Addresses
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Port is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      networkRef:
+                        description: networkRef is a reference to the ORC Network
+                          which this port is associated with.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  addresses:
+                    description: addresses are the IP addresses for the port.
+                    items:
+                      properties:
+                        ip:
+                          description: |-
+                            ip contains a fixed IP address assigned to the port. It must belong
+                            to the referenced subnet's CIDR. If not specified, OpenStack
+                            allocates an available IP from the referenced subnet.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        subnetRef:
+                          description: |-
+                            subnetRef references the subnet from which to allocate the IP
+                            address.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - subnetRef
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  allowedAddressPairs:
+                    description: allowedAddressPairs are allowed addresses associated
+                      with this port.
+                    items:
+                      properties:
+                        ip:
+                          description: |-
+                            ip contains an IP address which a server connected to the port can
+                            send packets with. It can be an IP Address or a CIDR (if supported
+                            by the underlying extension plugin).
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        mac:
+                          description: |-
+                            mac contains a MAC address which a server connected to the port can
+                            send packets with. Defaults to the MAC address of the port.
+                          maxLength: 17
+                          minLength: 1
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  name:
+                    description: name is a human-readable name of the port. If not
+                      set, the object's name will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  networkRef:
+                    description: networkRef is a reference to the ORC Network which
+                      this port is associated with.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  securityGroupRefs:
+                    description: |-
+                      securityGroupRefs are the names of the security groups associated
+                      with this port.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      port.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                required:
+                - networkRef
+                type: object
+                x-kubernetes-validations:
+                - message: PortResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp is the administrative state of the port,
+                      which is up (true) or down (false).
+                    type: boolean
+                  allowedAddressPairs:
+                    description: |-
+                      allowedAddressPairs is a set of zero or more allowed address pair
+                      objects each where address pair object contains an IP address and
+                      MAC address.
+                    items:
+                      properties:
+                        ip:
+                          description: |-
+                            ip contains an IP address which a server connected to the port can
+                            send packets with.
+                          maxLength: 1024
+                          type: string
+                        mac:
+                          description: |-
+                            mac contains a MAC address which a server connected to the port can
+                            send packets with.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  deviceID:
+                    description: deviceID is the ID of the device that uses this port.
+                    maxLength: 1024
+                    type: string
+                  deviceOwner:
+                    description: deviceOwner is the entity type that uses this port.
+                    maxLength: 1024
+                    type: string
+                  fixedIPs:
+                    description: |-
+                      fixedIPs is a set of zero or more fixed IP objects each where fixed
+                      IP object contains an IP address and subnet ID from which the IP
+                      address is assigned.
+                    items:
+                      properties:
+                        ip:
+                          description: ip contains a fixed IP address assigned to
+                            the port.
+                          maxLength: 1024
+                          type: string
+                        subnetID:
+                          description: subnetID is the ID of the subnet this IP is
+                            allocated from.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  macAddress:
+                    description: macAddress is the MAC address of the port.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is the human-readable name of the resource.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  networkID:
+                    description: networkID is the ID of the attached network.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the resource.
+                    maxLength: 1024
+                    type: string
+                  propagateUplinkStatus:
+                    description: |-
+                      propagateUplinkStatus represents the uplink status propagation of
+                      the port.
+                    type: boolean
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  securityGroups:
+                    description: securityGroups contains the IDs of security groups
+                      applied to the port.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  status:
+                    description: status indicates the current status of the resource.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: routerinterfaces.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: RouterInterface
+    listKind: RouterInterfaceList
+    plural: routerinterfaces
+    singular: routerinterface
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RouterInterface is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              routerRef:
+                description: routerRef references the router to which this interface
+                  belongs.
+                maxLength: 253
+                minLength: 1
+                type: string
+              subnetRef:
+                description: subnetRef references the subnet the router interface
+                  is created on.
+                maxLength: 253
+                minLength: 1
+                type: string
+              type:
+                description: type specifies the type of the router interface.
+                enum:
+                - Subnet
+                maxLength: 8
+                minLength: 1
+                type: string
+            required:
+            - routerRef
+            - type
+            type: object
+            x-kubernetes-validations:
+            - message: subnetRef is required when type is 'Subnet' and not permitted
+                otherwise
+              rule: 'self.type == ''Subnet'' ? has(self.subnetRef) : !has(self.subnetRef)'
+            - message: RouterInterfaceResourceSpec is immutable
+              rule: self == oldSelf
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the port created for the
+                  router interface
+                maxLength: 1024
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: routers.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Router
+    listKind: RouterList
+    plural: routers
+    singular: router
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Router is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp represents the administrative state of the resource,
+                      which is up (true) or down (false). Default is true.
+                    type: boolean
+                  availabilityZoneHints:
+                    description: availabilityZoneHints is the availability zone candidate
+                      for the router.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  distributed:
+                    description: |-
+                      distributed indicates whether the router is distributed or not. It
+                      is available when dvr extension is enabled.
+                    type: boolean
+                  externalGateways:
+                    description: externalGateways is a list of external gateways for
+                      the router.
+                    items:
+                      properties:
+                        networkRef:
+                          description: |-
+                            networkRef is a reference to the ORC Network which the external
+                            gateway is on.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - networkRef
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  name:
+                    description: |-
+                      name is a human-readable name of the router. If not set, the
+                      object's name will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      router.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+                x-kubernetes-validations:
+                - message: RouterResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp is the administrative state of the router,
+                      which is up (true) or down (false).
+                    type: boolean
+                  availabilityZoneHints:
+                    description: |-
+                      availabilityZoneHints is the availability zone candidate for the
+                      router.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  externalGateways:
+                    description: externalGateways is a list of external gateways for
+                      the router.
+                    items:
+                      properties:
+                        networkID:
+                          description: networkID is the ID of the network the gateway
+                            is on.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  name:
+                    description: name is the human-readable name of the resource.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the resource.
+                    maxLength: 1024
+                    type: string
+                  status:
+                    description: status indicates the current status of the resource.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: securitygroups.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: SecurityGroup
+    listKind: SecurityGroupList
+    plural: securitygroups
+    singular: securitygroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecurityGroup is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                  rules:
+                    description: rules is a list of security group rules belonging
+                      to this SG.
+                    items:
+                      description: SecurityGroupRule defines a Security Group rule
+                      minProperties: 1
+                      properties:
+                        description:
+                          description: description is a human-readable description
+                            for the resource.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        direction:
+                          description: |-
+                            direction represents the direction in which the security group rule
+                            is applied. Can be ingress or egress.
+                          enum:
+                          - ingress
+                          - egress
+                          type: string
+                        ethertype:
+                          description: |-
+                            ethertype must be IPv4 or IPv6, and addresses represented in CIDR
+                            must match the ingress or egress rules.
+                          enum:
+                          - IPv4
+                          - IPv6
+                          type: string
+                        portRange:
+                          description: |-
+                            portRange sets the minimum and maximum ports range that the security group rule
+                            matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
+                            or equal to the PortRange.Max attribute value.
+                            If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
+                            should be an ICMP type
+                          properties:
+                            max:
+                              description: |-
+                                max is the maximum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
+                                to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
+                              format: int32
+                              maximum: 65535
+                              minimum: 0
+                              type: integer
+                            min:
+                              description: |-
+                                min is the minimum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
+                                to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
+                              format: int32
+                              maximum: 65535
+                              minimum: 0
+                              type: integer
+                          required:
+                          - max
+                          - min
+                          type: object
+                        protocol:
+                          description: protocol is the IP protocol is represented
+                            by a string
+                          enum:
+                          - ah
+                          - dccp
+                          - egp
+                          - esp
+                          - gre
+                          - icmp
+                          - icmpv6
+                          - igmp
+                          - ipip
+                          - ipv6-encap
+                          - ipv6-frag
+                          - ipv6-icmp
+                          - ipv6-nonxt
+                          - ipv6-opts
+                          - ipv6-route
+                          - ospf
+                          - pgm
+                          - rsvp
+                          - sctp
+                          - tcp
+                          - udp
+                          - udplite
+                          - vrrp
+                          type: string
+                        remoteIPPrefix:
+                          description: remoteIPPrefix is an IP address block. Should
+                            match the Ethertype (IPv4 or IPv6)
+                          format: cidr
+                          maxLength: 49
+                          minLength: 1
+                          type: string
+                      required:
+                      - ethertype
+                      type: object
+                      x-kubernetes-validations:
+                      - message: portRangeMax should be equal or greater than portRange.min
+                        rule: (!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol
+                          == 'udp' || self.protocol == 'dccp' || self.protocol ==
+                          'sctp' || self.protocol == 'udplite') || (self.portRange.min
+                          <= self.portRange.max))
+                      - message: When protocol is ICMP or ICMPv6 portRange.min should
+                          be between 0 and 255
+                        rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
+                          || !has(self.portRange)|| (self.portRange.min >= 0 && self.portRange.min
+                          <= 255)'
+                      - message: When protocol is ICMP or ICMPv6 portRange.max should
+                          be between 0 and 255
+                        rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
+                          || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max
+                          <= 255)'
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  stateful:
+                    description: stateful indicates if the security group is stateful
+                      or stateless.
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      security group.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                type: object
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is a Human-readable name for the security group.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the security group.
+                    maxLength: 1024
+                    type: string
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  rules:
+                    description: rules is a list of security group rules belonging
+                      to this SG.
+                    items:
+                      properties:
+                        description:
+                          description: description is a human-readable description
+                            for the resource.
+                          maxLength: 1024
+                          type: string
+                        direction:
+                          description: |-
+                            direction represents the direction in which the security group rule
+                            is applied. Can be ingress or egress.
+                          maxLength: 1024
+                          type: string
+                        ethertype:
+                          description: |-
+                            ethertype must be IPv4 or IPv6, and addresses represented in CIDR
+                            must match the ingress or egress rules.
+                          maxLength: 1024
+                          type: string
+                        id:
+                          description: id is the ID of the security group rule.
+                          maxLength: 1024
+                          type: string
+                        portRange:
+                          description: |-
+                            portRange sets the minimum and maximum ports range that the security group rule
+                            matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
+                            or equal to the PortRange.Max attribute value.
+                            If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
+                            should be an ICMP type
+                          properties:
+                            max:
+                              description: |-
+                                max is the maximum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
+                                to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
+                              format: int32
+                              type: integer
+                            min:
+                              description: |-
+                                min is the minimum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
+                                to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
+                              format: int32
+                              type: integer
+                          type: object
+                        protocol:
+                          description: |-
+                            protocol is the IP protocol can be represented by a string, an
+                            integer, or null
+                          maxLength: 1024
+                          type: string
+                        remoteGroupID:
+                          description: |-
+                            remoteGroupID is the remote group UUID to associate with this security group rule
+                            RemoteGroupID
+                          maxLength: 1024
+                          type: string
+                        remoteIPPrefix:
+                          description: remoteIPPrefix is an IP address block. Should
+                            match the Ethertype (IPv4 or IPv6)
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  stateful:
+                    description: stateful indicates if the security group is stateful
+                      or stateless.
+                    type: boolean
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: servers.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Server
+    listKind: ServerList
+    plural: servers
+    singular: server
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Server is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  flavorRef:
+                    description: flavorRef references the flavor to use for the server
+                      instance.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  imageRef:
+                    description: |-
+                      imageRef references the image to use for the server instance.
+                      NOTE: This is not required in case of boot from volume.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  ports:
+                    description: ports defines a list of ports which will be attached
+                      to the server.
+                    items:
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        portRef:
+                          description: |-
+                            portRef is a reference to a Port object. Server creation will wait for
+                            this port to be created and available.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      server.
+                    items:
+                      maxLength: 80
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  userData:
+                    description: |-
+                      userData specifies data which will be made available to the server at
+                      boot time, either via the metadata service or a config drive. It is
+                      typically read by a configuration service such as cloud-init or ignition.
+                    maxProperties: 1
+                    minProperties: 1
+                    properties:
+                      secretRef:
+                        description: secretRef is a reference to a Secret containing
+                          the user data for this server.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    type: object
+                required:
+                - flavorRef
+                - imageRef
+                - ports
+                type: object
+                x-kubernetes-validations:
+                - message: ServerResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  hostID:
+                    description: hostID is the host where the server is located in
+                      the cloud.
+                    maxLength: 1024
+                    type: string
+                  imageID:
+                    description: imageID indicates the OS image used to deploy the
+                      server.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is the human-readable name of the resource.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  status:
+                    description: |-
+                      status contains the current operational status of the server,
+                      such as IN_PROGRESS or ACTIVE.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: subnets.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Subnet
+    listKind: SubnetList
+    plural: subnets
+    singular: subnet
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Subnet is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      cidr:
+                        description: cidr of the existing resource
+                        format: cidr
+                        maxLength: 49
+                        minLength: 1
+                        type: string
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      gatewayIP:
+                        description: gatewayIP is the IP address of the gateway of
+                          the existing resource
+                        maxLength: 45
+                        minLength: 1
+                        type: string
+                      ipVersion:
+                        description: ipVersion of the existing resource
+                        enum:
+                        - 4
+                        - 6
+                        format: int32
+                        type: integer
+                      ipv6:
+                        description: ipv6 options of the existing resource
+                        minProperties: 1
+                        properties:
+                          addressMode:
+                            description: addressMode specifies mechanisms for assigning
+                              IPv6 IP addresses.
+                            enum:
+                            - slaac
+                            - dhcpv6-stateful
+                            - dhcpv6-stateless
+                            type: string
+                          raMode:
+                            description: |-
+                              raMode specifies the IPv6 router advertisement mode. It specifies whether
+                              the networking service should transmit ICMPv6 packets.
+                            enum:
+                            - slaac
+                            - dhcpv6-stateful
+                            - dhcpv6-stateless
+                            type: string
+                        type: object
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      networkRef:
+                        description: networkRef is a reference to the ORC Network
+                          which this subnet is associated with.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  allocationPools:
+                    description: |-
+                      allocationPools are IP Address pools that will be available for DHCP. IP
+                      addresses must be in CIDR.
+                    items:
+                      properties:
+                        end:
+                          description: end is the last IP address in the allocation
+                            pool.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        start:
+                          description: start is the first IP address in the allocation
+                            pool.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                      required:
+                      - end
+                      - start
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  cidr:
+                    description: cidr is the address CIDR of the subnet. It must match
+                      the IP version specified in IPVersion.
+                    format: cidr
+                    maxLength: 49
+                    minLength: 1
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  dnsNameservers:
+                    description: dnsNameservers are the nameservers to be set via
+                      DHCP.
+                    items:
+                      maxLength: 45
+                      minLength: 1
+                      type: string
+                    maxItems: 16
+                    type: array
+                    x-kubernetes-list-type: set
+                  dnsPublishFixedIP:
+                    description: |-
+                      dnsPublishFixedIP will either enable or disable the publication of
+                      fixed IPs to the DNS. Defaults to false.
+                    type: boolean
+                  enableDHCP:
+                    description: enableDHCP will either enable to disable the DHCP
+                      service.
+                    type: boolean
+                  gateway:
+                    description: |-
+                      gateway specifies the default gateway of the subnet. If not specified,
+                      neutron will add one automatically. To disable this behaviour, specify a
+                      gateway with a type of None.
+                    properties:
+                      ip:
+                        description: |-
+                          ip is the IP address of the default gateway, which must be specified if
+                          Type is `IP`. It must be a valid IP address, either IPv4 or IPv6,
+                          matching the IPVersion in SubnetResourceSpec.
+                        maxLength: 45
+                        minLength: 1
+                        type: string
+                      type:
+                        description: |-
+                          type specifies how the default gateway will be created. `Automatic`
+                          specifies that neutron will automatically add a default gateway. This is
+                          also the default if no Gateway is specified. `None` specifies that the
+                          subnet will not have a default gateway. `IP` specifies that the subnet
+                          will use a specific address as the default gateway, which must be
+                          specified in `IP`.
+                        enum:
+                        - None
+                        - Automatic
+                        - IP
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  hostRoutes:
+                    description: hostRoutes are any static host routes to be set via
+                      DHCP.
+                    items:
+                      properties:
+                        destination:
+                          description: destination for the additional route.
+                          format: cidr
+                          maxLength: 49
+                          minLength: 1
+                          type: string
+                        nextHop:
+                          description: nextHop for the additional route.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                      required:
+                      - destination
+                      - nextHop
+                      type: object
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  ipVersion:
+                    description: ipVersion is the IP version for the subnet.
+                    enum:
+                    - 4
+                    - 6
+                    format: int32
+                    type: integer
+                  ipv6:
+                    description: ipv6 contains IPv6-specific options. It may only
+                      be set if IPVersion is 6.
+                    minProperties: 1
+                    properties:
+                      addressMode:
+                        description: addressMode specifies mechanisms for assigning
+                          IPv6 IP addresses.
+                        enum:
+                        - slaac
+                        - dhcpv6-stateful
+                        - dhcpv6-stateless
+                        type: string
+                      raMode:
+                        description: |-
+                          raMode specifies the IPv6 router advertisement mode. It specifies whether
+                          the networking service should transmit ICMPv6 packets.
+                        enum:
+                        - slaac
+                        - dhcpv6-stateful
+                        - dhcpv6-stateless
+                        type: string
+                    type: object
+                  name:
+                    description: name is a human-readable name of the subnet. If not
+                      set, the object's name will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  networkRef:
+                    description: networkRef is a reference to the ORC Network which
+                      this subnet is associated with.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  routerRef:
+                    description: routerRef specifies a router to attach the subnet
+                      to
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      subnet.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                required:
+                - cidr
+                - ipVersion
+                - networkRef
+                type: object
+                x-kubernetes-validations:
+                - message: SubnetResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  allocationPools:
+                    description: |-
+                      allocationPools is a list of sub-ranges within CIDR available for dynamic
+                      allocation to ports.
+                    items:
+                      properties:
+                        end:
+                          description: end is the last IP address in the allocation
+                            pool.
+                          maxLength: 1024
+                          type: string
+                        start:
+                          description: start is the first IP address in the allocation
+                            pool.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  cidr:
+                    description: cidr representing IP range for this subnet, based
+                      on IP version.
+                    maxLength: 1024
+                    type: string
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  dnsNameservers:
+                    description: dnsNameservers is a list of name servers used by
+                      hosts in this subnet.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 16
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  dnsPublishFixedIP:
+                    description: dnsPublishFixedIP specifies whether the fixed IP
+                      addresses are published to the DNS.
+                    type: boolean
+                  enableDHCP:
+                    description: enableDHCP specifies whether DHCP is enabled for
+                      this subnet or not.
+                    type: boolean
+                  gatewayIP:
+                    description: gatewayIP is the default gateway used by devices
+                      in this subnet, if any.
+                    maxLength: 1024
+                    type: string
+                  hostRoutes:
+                    description: |-
+                      hostRoutes is a list of routes that should be used by devices with IPs
+                      from this subnet (not including local subnet route).
+                    items:
+                      properties:
+                        destination:
+                          description: destination for the additional route.
+                          maxLength: 1024
+                          type: string
+                        nextHop:
+                          description: nextHop for the additional route.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  ipVersion:
+                    description: ipVersion specifies IP version, either `4' or `6'.
+                    format: int32
+                    type: integer
+                  ipv6AddressMode:
+                    description: ipv6AddressMode specifies mechanisms for assigning
+                      IPv6 IP addresses.
+                    maxLength: 1024
+                    type: string
+                  ipv6RAMode:
+                    description: |-
+                      ipv6RAMode is the IPv6 router advertisement mode. It specifies
+                      whether the networking service should transmit ICMPv6 packets.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is the human-readable name of the subnet. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  networkID:
+                    description: networkID is the ID of the network to which the subnet
+                      belongs.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the subnet.
+                    maxLength: 1024
+                    type: string
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  subnetPoolID:
+                    description: subnetPoolID is the id of the subnet pool associated
+                      with the subnet.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags optionally set via extensions/attributestags
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-leader-election-role
+  namespace: orc-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-image-editor-role
+rules:
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-image-viewer-role
+rules:
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - flavors
+  - images
+  - networks
+  - ports
+  - routerinterfaces
+  - routers
+  - securitygroups
+  - servers
+  - subnets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - flavors/status
+  - images/status
+  - networks/status
+  - ports/status
+  - routerinterfaces/status
+  - routers/status
+  - securitygroups/status
+  - servers/status
+  - subnets/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-leader-election-rolebinding
+  namespace: orc-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: orc-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: orc-manager-role
+subjects:
+- kind: ServiceAccount
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orc-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: orc-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-controller-manager-metrics-service
+  namespace: orc-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-controller-manager
+  namespace: orc-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: {{ cluster_api_openstack_controller_image }}:v{{ cluster_api_openstack_controller_version }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: orc-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/roles/clusterctl/defaults/main.yml
+++ b/roles/clusterctl/defaults/main.yml
@@ -23,6 +23,7 @@ clusterctl_checksums:
     1.5.1: 849c0dd9523d2b4916b199946794ceb9ad7f5ea70c56a635b70cdcf328c7a242
     1.6.0: 1f9d967b0a8fa8cf50fd86203658a8ddacbc7b4d5aafafccb1653aa0b38169ce
     1.8.4: a7f40cde4e4a4f7119a52713386238ebcfa8691e7683b5afb823439ea81a8729
+    1.9.6: e6a8843b3464eea3c5f98432128a914c5d8e44c2be1f308cf40a72aa98155d8c
   arm64:
     1.3.2: 1c409918fdbe693f0c2a4558ea1a35a0bacb9dcee258177f11ecded1e669191c
     1.3.3: f34abc7047f17d522757eb341cf64f05761b85fa9e1a4390a96adbb2482de784
@@ -30,6 +31,7 @@ clusterctl_checksums:
     1.5.1: 053f31b6bcd1440ff2da1863a44a32123fbb050078786221be54edd88df57398
     1.6.0: 0fd6ef67b82a8e570d9701458ef33933f6fbacde094895b66b8fb6b36a0a85d1
     1.8.4: 8fbaa26320fcdd11aa40e1e2ae4889f9743c33744e1d191eec2afca54d34bdbc
+    1.9.6: 49e80b6d6ac8ec4cf916ad434b12e703cd87b3edd3ee853b80da2510e6839d34
 
 clusterctl_download_url: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v{{ clusterctl_version }}/clusterctl-linux-{{ download_artifact_goarch }}" # noqa: yaml[line-length]
 clusterctl_download_dest: /usr/local/bin/clusterctl


### PR DESCRIPTION
In CAPO version v0.11.2 there is a severe bug allowing to accomplish
Denial of Service by any tenant.

Manual removal of VM by tenant which is managed by CAPO results
in a pod crash in a loop. This has been fixed with [1] and is part
of the 0.12.2 release.