### PR TITLE
Allow pip packages to be optionally installed into a virtualenv

### DIFF
--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -40,3 +40,31 @@ kubernetes_coredns_node_selector:
 
 # Allow custom CA usage in the cluster
 kubernetes_allow_custom_ca: false
+
+# Base python packages required with, or without an ansible target venv
+# NOTE(jrosser) An ansible target venv must be used on python>=3.12 due to pep-668
+kubernetes_pip_packages_base:
+  - kubernetes     # this needs to be newer than the version in many distro packages
+
+# Additional python packages required if using an ansible target venv
+kubernetes_pip_packages_venv:
+  - cryptography   # required to examine certificates
+  - pyyaml         # required for helm
+  - kubernetes     # required for kubernetes upgrade check
+
+# Python packages to install
+kubernetes_pip_packages_install: "{{ kubernetes_pip_packages_base +
+                                        (ansible_collection_kubernetes_target_venv is defined) | ternary(kubernetes_pip_packages_venv, []) +
+                                        (kubernetes_pip_packages_extra | default([])) }}"
+
+# Distro packages to install
+kubernetes_distro_packages_base:
+  - python3-pip
+
+# Distro packages to install when an ansible target venv is not in use
+kubernetes_distro_packages_no_venv:
+  - python3-cryptography
+
+kubernetes_distro_packages_install: "{{ kubernetes_distro_packages_base +
+					(ansible_collection_kubernetes_target_venv is defined) | ternary([], kubernetes_distro_packages_no_venv) +
+                                        kubernetes_distro_packages_extra | default([]) }}"

--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -37,15 +37,14 @@
     insertbefore: EOF
 
 # TODO(fitbeard): Move common system packages from all roles to dedicated role.
-- name: Install PIP
+- name: Install distro packages
   ansible.builtin.package:
-    name:
-      - python3-pip
-      - python3-cryptography
+    name: "{{ kubernetes_distro_packages_install | select }}"
 
-- name: Install Kubernetes python package
+- name: Install pip packages
   ansible.builtin.pip:
-    name: kubernetes
+    name: "{{ kubernetes_pip_packages_install | select }}"
+    virtualenv: "{{ ansible_collection_kubernetes_target_venv | default(omit) }}"
 
 - name: Allow workload on control plane node
   kubernetes.core.k8s_taint:


### PR DESCRIPTION
pep-668 will force installation of python modules with pip into a virtualenv rather than the system python. This is already required for debian-12 and ubuntu-24.04.

This patch allows the caller of ansible-collection-kubernetes to pass the path to a pre-created virtualenv to install python target host requirements for ansible modules into.