### PR TITLE
Fix PyYAML conflict for non-venv deployments

### DIFF
--- a/changelogs/fragments/pip-k8s-pyaml-conflict.yaml
+++ b/changelogs/fragments/pip-k8s-pyaml-conflict.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixes a PIP installation conflict with PyYAML for k8s when virtualenv is not used.

--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -52,10 +52,11 @@ kubernetes_pip_packages_venv:
   - pyyaml         # required for helm
 
 # Python packages to install
+kubernetes_use_venv: "{{ (ansible_collection_kubernetes_target_venv is defined and ansible_collection_kubernetes_target_venv | length > 0) }}"
 kubernetes_pip_packages_install: >-
   {{
     kubernetes_pip_packages_base +
-    (ansible_collection_kubernetes_target_venv is defined) | ternary(kubernetes_pip_packages_venv, []) +
+    kubernetes_use_venv | ternary(kubernetes_pip_packages_venv, []) +
     (kubernetes_pip_packages_extra | default([]))
   }}
 
@@ -75,7 +76,9 @@ kubernetes_distro_packages_venv:
 kubernetes_distro_packages_install: >-
   {{
     kubernetes_distro_packages_base +
-    (ansible_collection_kubernetes_target_venv is defined) | ternary(
+    kubernetes_use_venv | ternary(
       kubernetes_distro_packages_venv[ansible_facts['os_family'] | lower], kubernetes_distro_packages_no_venv) +
     kubernetes_distro_packages_extra | default([])
   }}
+
+kubernetes_distro_packages_remove: "{{ kubernetes_use_venv | ternary([], ['python3-yaml']) }}"

--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -36,7 +36,11 @@
     line: "source <(kubectl completion bash)"
     insertbefore: EOF
 
-# TODO(fitbeard): Move common system packages from all roles to dedicated role.
+- name: Remove conflicting packages
+  ansible.builtin.package:
+    name: "{{ kubernetes_distro_packages_remove | select }}"
+    state: absent
+
 - name: Install distro packages
   ansible.builtin.package:
     name: "{{ kubernetes_distro_packages_install | select }}"


### PR DESCRIPTION
Some images have python3-yaml pre-installed, and with latest release minimal  PyYAML version has been bumped to 6.0.3, which raises a conflict with distro-installed version.

We're uninstalling python3-yaml distro package to install it with PIP. Though it's high;y suggested to use `ansible_collection_kubernetes_target_venv` to use the venv.

Signed-off-by: Dmitriy Rabotyagov <dmitriy@adria-cloud.com>