### PR TITLE
Update source versions to upgrade from

### DIFF
--- a/molecule/cluster-api-upgrade/prepare.yml
+++ b/molecule/cluster-api-upgrade/prepare.yml
@@ -22,7 +22,8 @@
     - role: adriacloud.kubernetes.cert_manager
     - role: adriacloud.kubernetes.cluster_api
       vars:
-        clusterctl_version: 1.9.6
-        cluster_api_version: 1.9.6
+        clusterctl_version: 1.12.3
+        cluster_api_version: 1.12.3
         cluster_api_infrastructure_provider: openstack
         cluster_api_infrastructure_version: 0.12.2
+        cluster_api_openstack_controller_version: 2.3.3

--- a/molecule/cluster-api/molecule.yml
+++ b/molecule/cluster-api/molecule.yml
@@ -37,16 +37,16 @@ provisioner:
   inventory:
     group_vars:
       all:
-        kubernetes_version: ${KUBERNETES_VERSION:-1.35.2}
+        kubernetes_version: ${KUBERNETES_VERSION:-1.36.1}
         cilium_helm_values:
           operator:
             replicas: 1
       controllers:
-        clusterctl_version: ${CLUSTER_API_VERSION:-1.12.3}
-        cluster_api_version: ${CLUSTER_API_VERSION:-1.12.3}
+        clusterctl_version: ${CLUSTER_API_VERSION:-1.13.2}
+        cluster_api_version: ${CLUSTER_API_VERSION:-1.13.2}
         cluster_api_infrastructure_provider: openstack
-        cluster_api_infrastructure_version: ${CLUSTER_API_INFRA_VERSION:-0.14.1}
-        cluster_api_openstack_controller_version: ${CLUSTER_API_OPENSTACK_CONTROLLER:-2.4.0}
+        cluster_api_infrastructure_version: ${CLUSTER_API_INFRA_VERSION:-0.14.4}
+        cluster_api_openstack_controller_version: ${CLUSTER_API_OPENSTACK_CONTROLLER:-2.5.0}
         cluster_api_node_selector:
           kubernetes.io/os: linux
         keepalived_interface: "{{ ansible_facts['default_ipv4'].interface }}"


### PR DESCRIPTION
We bump source versions for capi upgrade to prior defaults, as otherwise the gap becomes too big to ignore.