### PR TITLE
Add retry logic for coredns deployment

### DIFF
--- a/changelogs/fragments/kube-vip-join-fix.yaml
+++ b/changelogs/fragments/kube-vip-join-fix.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - Fixes a race condition during control plane node joins where `kube-vip` started up prematurely
+    and bound the VIP address locally before `kubeadm join` completed.
+  - Fixes authorization issues for `kube-vip` on secondary control plane nodes in Kubernetes >= 1.29
+    by using `/etc/kubernetes/super-admin.conf` to bypass RBAC during bootstrap.

--- a/molecule/cluster-upgrade/molecule.yml
+++ b/molecule/cluster-upgrade/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     environment:
       container: docker
     tmpfs:
-      - /var/lib/etcd:rw,noexec,nosuid,size=128m
+      - /var/lib/etcd:rw,noexec,nosuid,size=512m
     security_opts:
       - apparmor=unconfined
     volumes:

--- a/molecule/cluster-upgrade/molecule.yml
+++ b/molecule/cluster-upgrade/molecule.yml
@@ -28,6 +28,8 @@ platforms:
       k8s: 172.17.0.100
     environment:
       container: docker
+    tmpfs:
+      - /var/lib/etcd:rw,noexec,nosuid,size=128m
     security_opts:
       - apparmor=unconfined
     volumes:

--- a/molecule/cluster-upgrade/prepare.yml
+++ b/molecule/cluster-upgrade/prepare.yml
@@ -27,5 +27,6 @@
         kind: Node
         name: "{{ inventory_hostname_short }}"
         wait: true
+        wait_timeout: 600
         wait_condition:
           type: Ready

--- a/molecule/ha/molecule.yml
+++ b/molecule/ha/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     environment:
       container: docker
     tmpfs:
-      - /var/lib/etcd:rw,noexec,nosuid,size=128m
+      - /var/lib/etcd:rw,noexec,nosuid,size=512m
     security_opts:
       - apparmor=unconfined
     volumes:

--- a/molecule/ha/molecule.yml
+++ b/molecule/ha/molecule.yml
@@ -28,6 +28,8 @@ platforms:
       k8s: 172.17.0.100
     environment:
       container: docker
+    tmpfs:
+      - /var/lib/etcd:rw,noexec,nosuid,size=128m
     security_opts:
       - apparmor=unconfined
     volumes:

--- a/molecule/kubernetes/verify.yml
+++ b/molecule/kubernetes/verify.yml
@@ -34,9 +34,12 @@
     - name: Get all nodes
       ansible.builtin.command: kubectl get nodes
       register: nodes
-      failed_when:
-        - nodes.rc != 0
-        - not(nodes.stdout.find('instance') != -1)
+      until:
+        - nodes.rc == 0
+        - nodes.stdout.find('NotReady') == -1
+        - nodes.stdout.find('instance') != -1
+      retries: 30
+      delay: 10
 
     - name: Print node list
       ansible.builtin.debug:

--- a/plugins/action/kubeadm_upgrade_node.py
+++ b/plugins/action/kubeadm_upgrade_node.py
@@ -118,10 +118,24 @@ class ActionModule(ActionBase):
             result.update({"changed": False})
             return result
 
+        stat_ret = self._execute_module(
+            module_name="ansible.builtin.stat",
+            module_args={
+                "path": "/etc/kubernetes/super-admin.conf",
+            },
+            task_vars=task_vars,
+            tmp=tmp,
+        )
+        super_admin_exists = (
+            not stat_ret.get("failed")
+            and stat_ret.get("stat", {}).get("exists")
+        )
+        kubeconfig_arg = " --kubeconfig /etc/kubernetes/super-admin.conf" if super_admin_exists else ""
+
         ret = self._execute_module(
             module_name="ansible.builtin.command",
             module_args={
-                "_raw_params": "kubeadm upgrade node",
+                "_raw_params": f"kubeadm upgrade node{kubeconfig_arg}",
             },
             task_vars=task_vars,
             tmp=tmp,

--- a/roles/kube_vip/tasks/main.yml
+++ b/roles/kube_vip/tasks/main.yml
@@ -12,47 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure destination directories exist
-  ansible.builtin.file:
-    path: /etc/kubernetes/manifests
-    mode: "0755"
-    state: directory
-
-- name: Uninstall legacy HA stack
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /etc/keepalived/keepalived.conf
-    - /etc/keepalived/check_apiserver.sh
-    - /etc/kubernetes/manifests/keepalived.yaml
-    - /etc/haproxy/haproxy.cfg
-    - /etc/kubernetes/manifests/haproxy.yaml
-  notify:
-    - Restart "kubelet" service
-
-- name: Switch API server to run on port 6443
-  ignore_errors: true
-  ansible.builtin.replace:
-    path: "{{ item }}"
-    regexp: "16443"
-    replace: "6443"
-  loop:
-    - /etc/kubernetes/manifests/kube-apiserver.yaml
-    - /etc/kubernetes/controller-manager.conf
-    - /etc/kubernetes/scheduler.conf
-  register: kube_vip_port_change
-  failed_when: kube_vip_port_change.rc != 0 and kube_vip_port_change.rc != 257
-  notify:
-    - Restart "kubelet" service
-
-- name: Check if super-admin.conf exists
-  ansible.builtin.stat:
-    path: /etc/kubernetes/super-admin.conf
-  failed_when: false
-  changed_when: false
-  register: kube_vip_stat_super_admin
-
 - name: Check if kubeadm has already run
   ansible.builtin.stat:
     path: /var/lib/kubelet/config.yaml
@@ -61,36 +20,80 @@
     get_mime: false
   register: kube_vip_stat_kubelet_config
 
-- name: Set fact with KUBECONFIG path
-  ansible.builtin.set_fact:
-    kube_vip_kubeconfig_path: /etc/kubernetes/admin.conf
-
-- name: Set fact with KUBECONFIG path (with super-admin.conf)
-  ansible.builtin.set_fact:
-    kube_vip_kubeconfig_path: /etc/kubernetes/super-admin.conf
+- name: Configure kube-vip on bootstrap or joined control plane nodes
   when:
-    - inventory_hostname == groups[kube_vip_control_plane_group] | first
-    - (kube_vip_stat_super_admin.stat.exists and kube_vip_stat_super_admin.stat.isreg) or (not kube_vip_stat_kubelet_config.stat.exists)
+    - (inventory_hostname == (groups[kube_vip_control_plane_group] | first)) or (kube_vip_stat_kubelet_config.stat.exists)
+  block:
+    - name: Ensure destination directories exist
+      ansible.builtin.file:
+        path: /etc/kubernetes/manifests
+        mode: "0755"
+        state: directory
 
-- name: Upload Kubernetes kube-vip manifest
-  ansible.builtin.template:
-    src: kube-vip.yaml.j2
-    dest: /etc/kubernetes/manifests/kube-vip.yaml
-    owner: root
-    group: root
-    mode: "0640"
-  when:
-    - kube_vip_enabled | bool
+    - name: Uninstall legacy HA stack
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/keepalived/keepalived.conf
+        - /etc/keepalived/check_apiserver.sh
+        - /etc/kubernetes/manifests/keepalived.yaml
+        - /etc/haproxy/haproxy.cfg
+        - /etc/kubernetes/manifests/haproxy.yaml
+      notify:
+        - Restart "kubelet" service
 
-- name: Remove kube-vip configuration file when disabled
-  ansible.builtin.file:
-    path: /etc/kubernetes/manifests/kube-vip.yaml
-    state: absent
-    owner: root
-    group: root
-    mode: "0640"
-  when:
-    - not kube_vip_enabled | bool
+    - name: Switch API server to run on port 6443
+      ignore_errors: true
+      ansible.builtin.replace:
+        path: "{{ item }}"
+        regexp: "16443"
+        replace: "6443"
+      loop:
+        - /etc/kubernetes/manifests/kube-apiserver.yaml
+        - /etc/kubernetes/controller-manager.conf
+        - /etc/kubernetes/scheduler.conf
+      register: kube_vip_port_change
+      failed_when: kube_vip_port_change.rc != 0 and kube_vip_port_change.rc != 257
+      notify:
+        - Restart "kubelet" service
 
-- name: Flush handlers
-  ansible.builtin.meta: flush_handlers
+    - name: Check if super-admin.conf exists
+      ansible.builtin.stat:
+        path: /etc/kubernetes/super-admin.conf
+      failed_when: false
+      changed_when: false
+      register: kube_vip_stat_super_admin
+
+    - name: Set fact with KUBECONFIG path
+      ansible.builtin.set_fact:
+        kube_vip_kubeconfig_path: /etc/kubernetes/admin.conf
+
+    - name: Set fact with KUBECONFIG path (with super-admin.conf)
+      ansible.builtin.set_fact:
+        kube_vip_kubeconfig_path: /etc/kubernetes/super-admin.conf
+      when:
+        - (kube_vip_stat_super_admin.stat.exists and kube_vip_stat_super_admin.stat.isreg) or (not kube_vip_stat_kubelet_config.stat.exists)
+
+    - name: Upload Kubernetes kube-vip manifest
+      ansible.builtin.template:
+        src: kube-vip.yaml.j2
+        dest: /etc/kubernetes/manifests/kube-vip.yaml
+        owner: root
+        group: root
+        mode: "0640"
+      when:
+        - kube_vip_enabled | bool
+
+    - name: Remove kube-vip configuration file when disabled
+      ansible.builtin.file:
+        path: /etc/kubernetes/manifests/kube-vip.yaml
+        state: absent
+        owner: root
+        group: root
+        mode: "0640"
+      when:
+        - not kube_vip_enabled | bool
+
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers

--- a/roles/kube_vip/templates/kube-vip.yaml.j2
+++ b/roles/kube_vip/templates/kube-vip.yaml.j2
@@ -99,7 +99,11 @@ spec:
   hostAliases:
   - hostnames:
     - kubernetes
-    - "{{ kubernetes_hostname | default('kubernetes') }}"
+{% if kubernetes_hostname is defined
+     and kubernetes_hostname is not match('^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$')
+     and kubernetes_hostname is not match('^([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F]{1,4}$') %}
+    - {{ kubernetes_hostname }}
+{% endif %}
     ip: 127.0.0.1
   hostNetwork: true
   volumes:

--- a/roles/kube_vip/templates/kube-vip.yaml.j2
+++ b/roles/kube_vip/templates/kube-vip.yaml.j2
@@ -99,6 +99,7 @@ spec:
   hostAliases:
   - hostnames:
     - kubernetes
+    - "{{ kubernetes_hostname | default('kubernetes') }}"
     ip: 127.0.0.1
   hostNetwork: true
   volumes:

--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -62,17 +62,41 @@
         key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+  register: kubernetes_allow_workload_result
+  until: kubernetes_allow_workload_result is not failed
+  retries: 15
+  delay: 5
+
 
 - name: Upgrade if necessary
   when:
     - kubernetes_upgrade_check_upgrade_required is defined
     - kubernetes_upgrade_check_upgrade_required | bool
   block:
+    - name: Check if super-admin.conf exists
+      ansible.builtin.stat:
+        path: /etc/kubernetes/super-admin.conf
+      register: kubernetes_stat_super_admin
+
+    - name: Set kubeadm kubeconfig path
+      ansible.builtin.set_fact:
+        kubernetes_kubeadm_kubeconfig: >-
+          {{ kubernetes_stat_super_admin.stat.exists |
+          ternary('/etc/kubernetes/super-admin.conf', '/etc/kubernetes/admin.conf') }}
+
     - name: Start an upgrade
       run_once: true
       changed_when: true
-      ansible.builtin.shell: |
-        kubeadm upgrade apply --v=5 --yes v{{ kubernetes_version }}
+      ansible.builtin.command:
+        argv:
+          - kubeadm
+          - upgrade
+          - apply
+          - --kubeconfig
+          - "{{ kubernetes_kubeadm_kubeconfig }}"
+          - --v=5
+          - "--yes"
+          - "v{{ kubernetes_version }}"
 
     - name: Check if the Kubernetes API services is up to date # noqa: var-naming[no-role-prefix]
       ansible.builtin.command:
@@ -84,6 +108,11 @@
     - name: Trigger an upgrade of the Kubernetes API services
       throttle: 1
       changed_when: true
-      ansible.builtin.shell: |
-        kubeadm upgrade node
+      ansible.builtin.command:
+        argv:
+          - kubeadm
+          - upgrade
+          - node
+          - --kubeconfig
+          - "{{ kubernetes_kubeadm_kubeconfig }}"
       when: kube_apiserver_version_check is failed

--- a/roles/kubernetes/tasks/join-cluster.yml
+++ b/roles/kubernetes/tasks/join-cluster.yml
@@ -12,6 +12,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Wait for Kubernetes API server to be ready
+  ansible.builtin.uri:
+    url: "https://{{ kubernetes_hostname | default('k8s') }}:6443/readyz"
+    validate_certs: false
+    timeout: 5
+  register: _kubernetes_api_ready
+  until:
+    - _kubernetes_api_ready.status is defined
+    - _kubernetes_api_ready.status == 200
+  retries: 60
+  delay: 5
+
 - name: Generate control-plane certificates for joining cluster
   run_once: true
   delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
@@ -20,6 +32,35 @@
   register: kubernetes_kubeadm_init_upload_certs
   when:
     - inventory_hostname in groups[kubernetes_control_plane_group]
+
+- name: Copy super-admin.conf from bootstrap node
+  when:
+    - inventory_hostname in groups[kubernetes_control_plane_group]
+  block:
+    - name: Check if super-admin.conf exists on bootstrap node
+      run_once: true
+      delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+      ansible.builtin.stat:
+        path: /etc/kubernetes/super-admin.conf
+      register: kubernetes_bootstrap_super_admin_stat
+
+    - name: Copy super-admin.conf from bootstrap node to joining control-plane nodes
+      delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+      ansible.builtin.slurp:
+        src: /etc/kubernetes/super-admin.conf
+      register: kubernetes_super_admin_file
+      when:
+        - kubernetes_bootstrap_super_admin_stat.stat.exists
+
+    - name: Write super-admin.conf to joining control-plane nodes
+      ansible.builtin.copy:
+        content: "{{ kubernetes_super_admin_file.content | b64decode }}"
+        dest: /etc/kubernetes/super-admin.conf
+        owner: root
+        group: root
+        mode: "0600"
+      when:
+        - kubernetes_bootstrap_super_admin_stat.stat.exists
 
 - name: Retrieve SHA256 certificate hash
   run_once: true
@@ -53,3 +94,7 @@
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   args:
     creates: /etc/kubernetes/kubelet.conf
+
+- name: Configure kube-vip on the joined control plane node
+  ansible.builtin.import_role:
+    name: adriacloud.kubernetes.kube_vip

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -43,3 +43,7 @@
         template:
           spec:
             nodeSelector: "{{ kubernetes_coredns_node_selector }}"
+  register: kubernetes_coredns_node_selector_result
+  until: kubernetes_coredns_node_selector_result is not failed
+  retries: 15
+  delay: 5


### PR DESCRIPTION
This also ensures that molecule tests in CI are more reliable by mounting tmpfs for etcd and we can reach the VIP through the hostname when node is being failovered.