### PR TITLE
Define default for kubernetes_bootstrap_node

### DIFF
--- a/changelogs/fragments/define-kubernetes-bootstrap-node.yaml
+++ b/changelogs/fragments/define-kubernetes-bootstrap-node.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Variable `kubernetes_bootstrap_node` is now defined by default and is
+    set to the first host in the control-plane group by default.
+    Dynamic defenition based on presence of admin.conf on the target node
+    is removed.

--- a/roles/kubernetes/README.md
+++ b/roles/kubernetes/README.md
@@ -1,1 +1,61 @@
-# `kubernetes`
+# kubernetes
+
+This role is responsible for bootstrapping and managing a Kubernetes cluster using `kubeadm`. It handles the initialization of the bootstrap control-plane node, uploading control-plane certificates, joining additional control-plane or worker nodes to the cluster, configuring custom CA certificates, and upgrading cluster components.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kubernetes_version` | `1.36.1` | The version of Kubernetes components to install and upgrade. |
+| `kubernetes_bootstrap_node` | First host in `kubernetes_control_plane_group` | The control-plane host selected to bootstrap the cluster. |
+| `kubernetes_control_plane_group` | `controllers` | Name of the Ansible inventory group containing all control-plane hosts. |
+| `kubernetes_image_repository` | `registry.k8s.io` | Container registry to pull Kubernetes system images from. |
+| `kubernetes_non_init_namespace` | `{{ ansible_connection == 'community.docker.docker' }}` | If deployed in a container (docker/LXC), prevents `kube-proxy` from adjusting host conntrack settings. |
+| `kubernetes_coredns_node_selector` | `{"openstack-control-plane": "enabled"}` | Node selector mapping applied to the CoreDNS deployment. |
+| `kubernetes_allow_custom_ca` | `false` | Whether to upload and configure a custom set of CA certificates. |
+| `kubernetes_node_ip` | `{{ kubelet_node_ip }}` | *Deprecated*. Use `kubelet_node_ip` instead. |
+| `kubernetes_cri_socket` | `{{ kubelet_cri_socket }}` | *Deprecated*. Use `kubelet_cri_socket` instead. |
+| `kubernetes_allow_unsafe_swap` | `false` | *Deprecated*. Use `kubelet_allow_unsafe_swap` instead. |
+
+### Custom CA Variables
+
+When `kubernetes_allow_custom_ca` is set to `true`, the following variables can be configured to provide custom keys and certificates for Kubernetes, etcd, and front-proxy CAs:
+
+* `kubernetes_custom_ca_key`: Private key content for the Kubernetes cluster CA.
+* `kubernetes_custom_ca_cert`: Certificate content for the Kubernetes cluster CA.
+* `kubernetes_custom_etcd_ca_key`: Private key content for the etcd CA.
+* `kubernetes_custom_etcd_ca_cert`: Certificate content for the etcd CA.
+* `kubernetes_custom_front_proxy_ca_key`: Private key content for the front-proxy CA.
+* `kubernetes_custom_front_proxy_ca_cert`: Certificate content for the front-proxy CA.
+
+### Package Management Variables
+
+These variables control the Python and distribution packages installed on target hosts:
+
+* `kubernetes_pip_packages_base`: List of fundamental Python pip packages required (default: `['kubernetes']`).
+* `kubernetes_pip_packages_venv`: Additional Python packages installed when running inside a target virtual environment (default: `['cryptography', 'pyyaml']`).
+* `kubernetes_use_venv`: Boolean to specify if the role should utilize an Ansible target virtual environment.
+* `kubernetes_pip_packages_install`: Final calculated list of pip packages to install.
+* `kubernetes_distro_packages_base`: System packages required by the role (default: `['python3-pip']`).
+* `kubernetes_distro_packages_no_venv`: System packages required when not using a virtual environment (default: `['python3-cryptography']`).
+* `kubernetes_distro_packages_venv`: System packages required when using a virtual environment, mapped by OS family.
+* `kubernetes_distro_packages_install`: Final calculated list of system distribution packages to install.
+* `kubernetes_distro_packages_remove`: System packages to remove to avoid conflicts.
+
+## Example Playbook
+
+The following playbook initializes a Kubernetes cluster using the `kubernetes` role:
+
+```yaml
+- name: Deploy Kubernetes Cluster
+  hosts: all
+  roles:
+    - role: adriacloud.kubernetes.kubernetes
+      vars:
+        kubernetes_version: 1.36.1
+        kubernetes_control_plane_group: control_plane_nodes
+```
+
+## License
+
+Apache-2.0

--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -15,6 +15,9 @@
 # Kuberentes version
 kubernetes_version: 1.36.1
 
+# The host that will bootstrap the cluster
+kubernetes_bootstrap_node: "{{ groups[kubernetes_control_plane_group] | first }}"
+
 # Name of Ansible group containing all control-plane nodes
 kubernetes_control_plane_group: controllers
 

--- a/roles/kubernetes/tasks/bootstrap-cluster.yml
+++ b/roles/kubernetes/tasks/bootstrap-cluster.yml
@@ -12,30 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Determine node to use for bootstrapping cluster
-  block:
-    - name: Check if any control plane is bootstrapped
-      ansible.builtin.stat:
-        path: /etc/kubernetes/admin.conf
-      register: kubernetes_admin_conf_stat
-      loop: "{{ groups[kubernetes_control_plane_group] }}"
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-
-- name: Pick node from pre-existing cluster
-  ansible.builtin.set_fact:
-    kubernetes_bootstrap_node: "{{ kubernetes_admin_conf_stat.results | selectattr('stat.exists', 'equalto', true) | map(attribute='item') | first }}"
-  when: kubernetes_admin_conf_stat.results | selectattr('stat.exists', 'equalto', true) | length > 0
-
-- name: Select first node to initialize cluster
-  ansible.builtin.set_fact:
-    kubernetes_bootstrap_node: "{{ groups[kubernetes_control_plane_group] | first }}"
-  when: kubernetes_admin_conf_stat.results | selectattr('stat.exists', 'equalto', true) | length == 0
-
-- name: Print selected bootstrap node
-  ansible.builtin.debug:
-    msg: "{{ kubernetes_bootstrap_node }}"
-
 - name: Upload cluster configuration for bootstrap node
   ansible.builtin.template:
     src: kubeadm.yaml.j2

--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -93,8 +93,6 @@
           - apply
           - --kubeconfig
           - "{{ kubernetes_kubeadm_kubeconfig }}"
-          - --config
-          - /etc/kubernetes/kubeadm.yaml
           - --v=5
           - "--yes"
           - "v{{ kubernetes_version }}"
@@ -116,8 +114,6 @@
           - node
           - --kubeconfig
           - "{{ kubernetes_kubeadm_kubeconfig }}"
-          - --config
-          - /etc/kubernetes/kubeadm.yaml
       register: _kubernetes_trigger_upgrade
       until: _kubernetes_trigger_upgrade is not failed
       retries: 3

--- a/roles/kubernetes/tasks/join-cluster.yml
+++ b/roles/kubernetes/tasks/join-cluster.yml
@@ -26,7 +26,7 @@
 
 - name: Check if super-admin.conf exists on bootstrap node
   run_once: true
-  delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+  delegate_to: "{{ kubernetes_bootstrap_node }}"
   ansible.builtin.stat:
     path: /etc/kubernetes/super-admin.conf
   register: kubernetes_bootstrap_super_admin_stat
@@ -39,7 +39,7 @@
 
 - name: Generate control-plane certificates for joining cluster
   run_once: true
-  delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+  delegate_to: "{{ kubernetes_bootstrap_node }}"
   ansible.builtin.command:
     argv:
       - kubeadm
@@ -62,7 +62,7 @@
     - kubernetes_bootstrap_super_admin_stat.stat.exists
   block:
     - name: Copy super-admin.conf from bootstrap node to joining control-plane nodes
-      delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+      delegate_to: "{{ kubernetes_bootstrap_node }}"
       ansible.builtin.slurp:
         src: /etc/kubernetes/super-admin.conf
       register: kubernetes_super_admin_file
@@ -77,14 +77,14 @@
 
 - name: Retrieve SHA256 certificate hash
   run_once: true
-  delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+  delegate_to: "{{ kubernetes_bootstrap_node  }}"
   community.crypto.x509_certificate_info:
     path: /etc/kubernetes/pki/ca.crt
   register: kubernetes_kubeadm_certificate_info
 
 - name: Generate token for joining cluster
   run_once: true
-  delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+  delegate_to: "{{ kubernetes_bootstrap_node }}"
   changed_when: true
   ansible.builtin.command:
     argv:

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Set node selector for CoreDNS components
   run_once: true
-  delegate_to: "{{ kubernetes_bootstrap_node | default(groups[kubernetes_control_plane_group][0]) }}"
+  delegate_to: "{{ kubernetes_bootstrap_node }}"
   vars:
     ansible_python_interpreter: "{{ ansible_collection_kubernetes_target_venv | default('/usr') }}/bin/python3"
   kubernetes.core.k8s:

--- a/roles/kubernetes/templates/kubeadm.yaml.j2
+++ b/roles/kubernetes/templates/kubeadm.yaml.j2
@@ -72,7 +72,7 @@ nodeRegistration:
     - name: container-runtime-endpoint
       value: "{{ kubelet_cri_socket }}"
 {% endif %}
-{% if (kubernetes_bootstrap_node is not defined) or (kubernetes_bootstrap_node is defined and inventory_hostname != kubernetes_bootstrap_node) %}
+{% if inventory_hostname != kubernetes_bootstrap_node %}
 discovery:
   bootstrapToken:
     token: "{{ kubernetes_kubeadm_token_create.stdout | trim }}"


### PR DESCRIPTION
With ditribution of admin.conf across all nodes, we can simplify the logic across the role and define default value for kubernetes_bootstrap_node